### PR TITLE
fix: correct garbage card entity reference to display actual state

### DIFF
--- a/custom_components/dashview/www/lib/ui/FloorManager.js
+++ b/custom_components/dashview/www/lib/ui/FloorManager.js
@@ -575,7 +575,7 @@ export class FloorManager {
     
     return garbageSensors
       .map(sensor => {
-        const entityState = this._hass.states[sensor.entity_id];
+        const entityState = this._hass.states[sensor.entity];
         
         // The entity state contains the calculated text like "Heute", "Morgen", "X Tage"
         // Instead of trying to parse it as a date, use it directly
@@ -607,7 +607,7 @@ export class FloorManager {
   }
 
   _generateGarbageCardHTML(sensor) {
-    const { entity_id, type, daysUntil, entityState, stateText } = sensor;
+    const { entity, type, daysUntil, entityState, stateText } = sensor;
     const icon = this._getGarbageTypeIcon(type);
     const typeName = this._getGarbageTypeName(type);
     
@@ -629,7 +629,7 @@ export class FloorManager {
 
     return `
       <div class="swiper-slide">
-        <div class="${cardClass}" data-entity-id="${entity_id}">
+        <div class="${cardClass}" data-entity-id="${entity}">
           <div class="garbage-card-grid">
             <div class="garbage-card-name">${typeName}</div>
             <div class="garbage-card-icon-cell"><i class="mdi ${this._panel._processIconName(icon)}"></i></div>


### PR DESCRIPTION
## Summary
- Fixed entity property mismatch in garbage card implementation that was causing "Datum unbekannt" to be displayed instead of actual entity states
- Changed `sensor.entity_id` to `sensor.entity` to match the configuration format used in AdminManager
- Updated destructuring and HTML data attributes accordingly
- Now correctly displays entity state values like "Heute", "Morgen", "in X Tagen"

## Root Cause
The garbage sensors are stored in the configuration with the property `entity` (as seen in AdminManager.js line 1304), but the FloorManager was looking for `entity_id`. This mismatch caused the entity state to be undefined, resulting in the fallback "Datum unbekannt" being displayed.

## Changes Made
1. **FloorManager.js line 578**: Changed `sensor.entity_id` to `sensor.entity` when getting entity state
2. **FloorManager.js line 610**: Updated destructuring from `entity_id` to `entity`  
3. **FloorManager.js line 632**: Updated HTML data attribute to use `entity`

## Test Plan
- [x] Validate JavaScript syntax with `node -c`
- [x] Verify no breaking changes to other components
- [x] Test that garbage cards now display actual entity states instead of "Datum unbekannt"

Fixes #240

🤖 Generated with [Claude Code](https://claude.ai/code)