### PR TITLE
fix: align garbage card and sensor big card formatting with room card blueprint

### DIFF
--- a/custom_components/dashview/www/style.css
+++ b/custom_components/dashview/www/style.css
@@ -2162,11 +2162,14 @@ body.popup-open, :host(.popup-open) {
 
 .garbage-card-name {
     grid-area: name;
-    font-size: 1.2em;
+    justify-self: start;
+    align-self: start;
+    text-align: left;
+    font-size: 16px;
     font-weight: 500;
     color: var(--gray800);
-    align-self: start;
-    padding-top: 5px;
+    padding: 14px;
+    word-break: break-word;
 }
 
 .garbage-card-icon-cell {
@@ -2528,8 +2531,12 @@ body.popup-open, :host(.popup-open) {
     grid-area: name;
     justify-self: start;
     align-self: start;
-    font-weight: 500;
+    text-align: left;
     font-size: 16px;
+    font-weight: 500;
+    color: var(--gray800);
+    padding: 14px;
+    word-break: break-word;
     opacity: 0.7;
 }
 


### PR DESCRIPTION
## Summary
- Fixed CSS formatting alignment between room cards, garbage cards, and sensor big cards
- Ensured 100% consistency in title formatting, icon positioning, and state text layout using room cards as the blueprint

## Changes Made
### Garbage Card Name (.garbage-card-name)
- **Font size**: Changed from `1.2em` to `16px` to match room cards
- **Padding**: Changed from `padding-top: 5px` to `padding: 14px` to match room cards  
- **Positioning**: Added missing `justify-self: start`, `align-self: start`, `text-align: left`
- **Text handling**: Added `word-break: break-word` for consistent text wrapping

### Sensor Big Card Name (.sensor-big-name)  
- **Positioning**: Added missing `text-align: left` for consistent alignment
- **Color**: Added explicit `color: var(--gray800)` property
- **Padding**: Added `padding: 14px` to match room cards
- **Text handling**: Added `word-break: break-word` for consistent text wrapping
- **Hierarchy**: Maintained existing `opacity: 0.7` for visual hierarchy

## Formatting Consistency Achieved
All three card types now have identical formatting for:

| Property | Room Card | Garbage Card | Sensor Big Card |
|----------|-----------|--------------|-----------------|
| **Title font-size** | 16px | 16px ✅ | 16px ✅ |
| **Title font-weight** | 500 | 500 ✅ | 500 ✅ |
| **Title padding** | 14px | 14px ✅ | 14px ✅ |
| **Icon cell size** | 50px × 50px | 50px × 50px ✅ | 50px × 50px ✅ |
| **Icon font-size** | 30px | 30px ✅ | 30px ✅ |
| **Icon positioning** | end/start | end/start ✅ | end/start ✅ |
| **State text font-size** | 1.5em | 1.5em ✅ | 1.5em ✅ |
| **State text font-weight** | 300 | 300 ✅ | 300 ✅ |
| **State text padding** | 0 0 14px 14px | 0 0 14px 14px ✅ | 0 0 14px 14px ✅ |

## Test Plan
- [x] Validated CSS syntax 
- [x] Verified JavaScript syntax
- [x] Confirmed no breaking changes to existing functionality
- [x] All card types now follow identical layout patterns

Fixes #232

🤖 Generated with [Claude Code](https://claude.ai/code)