### PR TITLE
fix: remove border-radius and padding from garbage card container

### DIFF
--- a/custom_components/dashview/www/style.css
+++ b/custom_components/dashview/www/style.css
@@ -2026,8 +2026,6 @@ body.popup-open, :host(.popup-open) {
 /* --- Garbage Collection Cards --- */
 .garbage-swipe-card-container {
     background: var(--gray000);
-    border-radius: 30px;
-    padding: 20px;
     position: relative;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- Remove border-radius and padding from `.garbage-swipe-card-container` CSS class
- Aligns garbage card styling with room card patterns for improved visual consistency
- Maintains container functionality while reducing visual clutter

## Test plan
- [x] Verify CSS syntax validation passes
- [x] Confirm git commit follows project conventions
- [ ] Visual testing of garbage card layout in DashView interface
- [ ] Regression testing to ensure no other components affected

🤖 Generated with [Claude Code](https://claude.ai/code)