### PR TITLE
Fix calendar admin error handling (fixes #307)

### DIFF
--- a/custom_components/dashview/www/lib/ui/AdminManager.js
+++ b/custom_components/dashview/www/lib/ui/AdminManager.js
@@ -226,8 +226,14 @@ export class AdminManager {
   }
 
   async _saveConfigViaAPI(configType, configData) {
-    await this._hass.callApi('POST', 'dashview/config', { type: configType, config: configData });
-    console.log(`[DashView] ${configType} configuration saved.`);
+    try {
+      await this._hass.callApi('POST', 'dashview/config', { type: configType, config: configData });
+      console.log(`[DashView] ${configType} configuration saved.`);
+      return { status: 'success' };
+    } catch (error) {
+      console.error(`[DashView] Error saving ${configType} configuration:`, error);
+      throw new Error(`Failed to save ${configType} configuration: ${error.message || 'Unknown error'}`);
+    }
   }
 
   _findRoomKeyByName(roomName) {
@@ -1646,11 +1652,28 @@ async saveMediaPlayerPresets() {
     try {
       // Fetch available calendars
       const calendarsResponse = await fetch('/api/dashview/config?type=available_calendars');
+      if (!calendarsResponse.ok) {
+        throw new Error(`Failed to fetch available calendars: ${calendarsResponse.status} ${calendarsResponse.statusText}`);
+      }
       const availableCalendars = await calendarsResponse.json();
+      
+      // Validate response data
+      if (!Array.isArray(availableCalendars)) {
+        throw new Error('Invalid response format: available calendars should be an array');
+      }
       
       // Fetch current calendar configuration
       const configResponse = await fetch('/api/dashview/config?type=calendar_config');
+      if (!configResponse.ok) {
+        throw new Error(`Failed to fetch calendar configuration: ${configResponse.status} ${configResponse.statusText}`);
+      }
       const calendarConfig = await configResponse.json();
+      
+      // Validate configuration response
+      if (!calendarConfig || typeof calendarConfig !== 'object') {
+        throw new Error('Invalid response format: calendar configuration should be an object');
+      }
+      
       const linkedCalendars = calendarConfig.linked_calendars || [];
       
       // Update admin local state
@@ -1688,7 +1711,11 @@ async saveMediaPlayerPresets() {
       this._setStatusMessage(statusElement, 'Calendar configuration loaded successfully', 'success');
     } catch (error) {
       console.error('[DashView] Error loading calendar configuration:', error);
-      this._setStatusMessage(statusElement, 'Error loading calendar configuration', 'error');
+      let errorMessage = 'Error loading calendar configuration';
+      if (error.message) {
+        errorMessage += `: ${error.message}`;
+      }
+      this._setStatusMessage(statusElement, errorMessage, 'error');
     }
   }
   
@@ -1718,11 +1745,15 @@ async saveMediaPlayerPresets() {
           this._panel._houseConfig.linked_calendars = selectedCalendars;
         }
       } else {
-        throw new Error('Failed to save calendar configuration');
+        throw new Error('Failed to save calendar configuration: Invalid response');
       }
     } catch (error) {
       console.error('[DashView] Error saving calendar configuration:', error);
-      this._setStatusMessage(statusElement, 'Error saving calendar configuration', 'error');
+      let errorMessage = 'Error saving calendar configuration';
+      if (error.message) {
+        errorMessage += `: ${error.message}`;
+      }
+      this._setStatusMessage(statusElement, errorMessage, 'error');
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes calendar admin error handling by adding proper HTTP response status checking
- Enhances error messages to provide more specific feedback to users
- Improves the _saveConfigViaAPI method with comprehensive error handling

## Test plan

- [x] Verify JavaScript syntax validation passes
- [x] Test existing calendar integration tests
- [x] Check for security issues (no eval/innerHTML vulnerabilities)
- [x] Validate Python backend syntax

## Changes Made

### AdminManager.js (`custom_components/dashview/www/lib/ui/AdminManager.js`)

1. **Enhanced loadCalendarManagement() method**:
   - Added HTTP response status checking for both `/api/dashview/config?type=available_calendars` and `/api/dashview/config?type=calendar_config` endpoints
   - Added response data validation to ensure proper array/object formats
   - Improved error messages with specific details about what failed

2. **Improved _saveConfigViaAPI() method**:
   - Added try-catch error handling around the Home Assistant API calls
   - Return proper success/failure status indication
   - Provide detailed error messages with context

3. **Enhanced saveCalendarManagement() method**:
   - Better error message formatting with specific error details
   - Consistent error handling pattern throughout

## Problem Solved

Previously, when the calendar admin section failed to load (due to network issues, backend problems, or invalid responses), users would only see a generic "Error loading calendar configuration" message with no indication of the actual problem.

Now users will see specific error messages like:
- "Error loading calendar configuration: Failed to fetch available calendars: 404 Not Found"
- "Error loading calendar configuration: Invalid response format: available calendars should be an array"
- "Error saving calendar configuration: Failed to save calendar configuration: Network error"

This makes it much easier to diagnose and resolve calendar configuration issues.

🤖 Generated with [Claude Code](https://claude.ai/code)