### PR TITLE
feat: add docked and cleaning states for mower sensor

### DIFF
--- a/custom_components/dashview/www/lib/ui/info-card-manager.js
+++ b/custom_components/dashview/www/lib/ui/info-card-manager.js
@@ -448,7 +448,7 @@ export class InfoCardManager {
     // Find any active mower
     const activeMower = mowerEntities.find(entityId => {
       const entity = this._hass.states[entityId];
-      return entity && ['mowing', 'returning', 'error', 'going_home'].includes(entity.state?.toLowerCase());
+      return entity && ['mowing', 'cleaning', 'returning', 'error', 'going_home', 'docked'].includes(entity.state?.toLowerCase());
     });
 
     if (!activeMower) {
@@ -463,8 +463,10 @@ export class InfoCardManager {
       const state = entity.state?.toLowerCase();
       let statusText = '';
       
-      if (state === 'mowing') {
+      if (state === 'mowing' || state === 'cleaning') {
         statusText = 'mäht 🚜';
+      } else if (state === 'docked') {
+        statusText = 'parkt 🚜';
       } else if (state === 'returning' || state === 'going_home') {
         statusText = 'kehrt zurück 🚜';
       } else if (state === 'error') {


### PR DESCRIPTION
## Summary
- Added support for 'docked' and 'cleaning' states in the mower sensor display
- 'docked' state displays as "parkt 🚜" (parked)
- 'cleaning' state displays as "mäht 🚜" (mowing), same as the existing 'mowing' state

## Changes
- Updated active mower detection to include 'docked' and 'cleaning' states
- Added display logic for the new states in the info card manager

## Test plan
- [x] JavaScript syntax validation passed
- [x] Test suite runs without errors
- [ ] Verify mower with 'docked' state shows "parkt 🚜"
- [ ] Verify mower with 'cleaning' state shows "mäht 🚜"
- [ ] Verify existing states still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)