### PR TITLE
Fix mower error detection to check entity state first

### DIFF
--- a/custom_components/dashview/www/lib/ui/FloorManager.js
+++ b/custom_components/dashview/www/lib/ui/FloorManager.js
@@ -1460,8 +1460,8 @@ export class FloorManager {
       return errorStr !== 'none' && errorStr !== 'no error' && errorStr !== 'ok' && errorStr !== '';
     };
 
-    // Handle error states - only if there is a valid error
-    if (isValidError(error) || isValidError(lastError)) {
+    // Handle error states - only if the entity state is "error" AND there is a valid error message
+    if (state === 'error' && (isValidError(error) || isValidError(lastError))) {
       let errorMessage = 'Fehler';
       // Use actual error value, but exclude "none" values when determining current error
       const validError = isValidError(error) ? error : null;
@@ -1521,6 +1521,9 @@ export class FloorManager {
         return { name: entityState?.attributes.friendly_name || 'Mower', icon: 'mdi:robot-mower-outline', label: 'Pausiert', cardClass: 'is-on' };
       case 'idle':
         return { name: entityState?.attributes.friendly_name || 'Mower', icon: 'mdi:robot-mower-outline', label: 'Bereit', cardClass: '' };
+      case 'error':
+        // Generic error state when no specific error message is available
+        return { name: entityState?.attributes.friendly_name || 'Mower', icon: 'mdi:robot-mower-alert', label: 'Fehler', cardClass: 'mower-error' };
       case 'ok':
         // Use activity if available
         if (activity) {


### PR DESCRIPTION
## Summary
Fixes the mower error detection logic in sensor-big cards to only show error messages when the entity state is actually `"error"`.

## Problem
The current implementation shows error messages whenever `error` or `last_error` attributes contain values, even when the mower is functioning normally. This leads to false positive error displays when the mower has historical error data but is currently operational.

## Solution
- **Primary Check**: Error detection now requires `entityState.state === 'error'`
- **Secondary Check**: AND a valid error message in `error` or `last_error` attributes
- **Fallback**: Added explicit case for `'error'` state with generic error handling

## Changes Made
- Updated error detection condition in `_getMowerDisplayData()` line 1464
- Added `case 'error':` in state switch statement for generic error handling
- Maintains all existing error message translations and logic

## Logic Flow
```javascript
// ✅ NEW: Only show error messages when state is "error"
if (state === 'error' && (isValidError(error) || isValidError(lastError))) {
    // Show specific error message with translation
}

// ✅ NEW: Handle generic error state
case 'error':
    return { label: 'Fehler', icon: 'mdi:robot-mower-alert', cardClass: 'mower-error' };
```

## Test plan
- [ ] Test mower with `state: "mowing"` and `error: "low_battery"` → Should show "Mäht"
- [ ] Test mower with `state: "error"` and `error: "low_battery"` → Should show "Akku schwach"  
- [ ] Test mower with `state: "error"` and `error: "none"` → Should show "Fehler"
- [ ] Test mower with `state: "charging"` and `last_error: "trapped"` → Should show "Lädt X%"

## Impact
- ✅ Eliminates false positive error displays
- ✅ Error messages only appear during actual error conditions
- ✅ Maintains all existing error message translations
- ✅ Backward compatible with existing mower integrations

🤖 Generated with [Claude Code](https://claude.ai/code)