### PR TITLE
fix: Remove debug console.log left in production (#80)

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -3381,15 +3381,7 @@ if (typeof structuredClone === 'undefined') {
     // ============================================
 
     _getAreaLights(areaId) {
-      const lights = roomDataService ? roomDataService.getAreaLights(areaId) : [];
-      // DEBUG: Log lights for each area (remove after debugging)
-      console.log(`[Dashview DEBUG] _getAreaLights("${areaId}"):`, lights.length, 'lights', lights.map(l => ({
-        id: l.entity_id,
-        domain: l.entity_id.split('.')[0],
-        state: l.state,
-        enabled: l.enabled
-      })));
-      return lights;
+      return roomDataService ? roomDataService.getAreaLights(areaId) : [];
     }
 
     _getAreaMotionSensors(areaId) {

--- a/custom_components/dashview/frontend/services/room-data-service.js
+++ b/custom_components/dashview/frontend/services/room-data-service.js
@@ -246,8 +246,6 @@ export class RoomDataService {
       if (config.excludeDomains && config.excludeDomains.length > 0) {
         const domain = entityReg.entity_id.split('.')[0];
         if (config.excludeDomains.includes(domain)) {
-          // DEBUG: Log when filtering out excluded domains (remove after debugging)
-          console.log(`[Dashview DEBUG] FILTERED OUT: "${entityReg.entity_id}" (domain: ${domain}, excluded: ${config.excludeDomains.join(',')})`);
           return false;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #80 — Debug console.log left in production code.

## Problem

Two `[Dashview DEBUG]` log statements fired on **every render for every room**, flooding the browser console with hundreds of lines per second:

- `dashview-panel.js` `_getAreaLights()` — logged all lights with full state for each area
- `room-data-service.js` `getAreaEntities()` — logged every filtered-out entity

Both had comments literally saying *'remove after debugging'*.

## Fix

Removed both debug log statements. -11 lines.