### PR TITLE
fix: Normalize garage height + add version footer (#99, #100)

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -4621,6 +4621,9 @@ if (typeof structuredClone === 'undefined') {
           ? dashviewChangelogPopup(this, html)
           : ''}
 
+        <!-- VERSION FOOTER -->
+        <div class="dashview-version">v${changelogUtils?.CURRENT_VERSION || DASHVIEW_VERSION}</div>
+
         <!-- BOTTOM TAB BAR -->
         <div class="bottom-tab-bar">
           <div class="bottom-tab-bar-inner">

--- a/custom_components/dashview/frontend/styles/layout/tab-bar.js
+++ b/custom_components/dashview/frontend/styles/layout/tab-bar.js
@@ -70,4 +70,13 @@ export const tabBarStyles = `
     max-width: 1200px;
     margin: 0 auto;
   }
+
+  /* ==================== VERSION FOOTER ==================== */
+  .dashview-version {
+    text-align: center;
+    font-size: 10px;
+    color: var(--dv-gray500);
+    padding: 16px 0 calc(80px + env(safe-area-inset-bottom, 0px)) 0;
+    opacity: 0.6;
+  }
 `;

--- a/custom_components/dashview/frontend/styles/popups/room.js
+++ b/custom_components/dashview/frontend/styles/popups/room.js
@@ -743,8 +743,8 @@ export const roomPopupStyles = `
   .popup-garage-item-header {
     display: flex;
     align-items: center;
-    height: 68px;
-    padding: 4px 20px 4px 4px;
+    height: 46px;
+    padding: 4px 12px 4px 4px;
     gap: 12px;
     cursor: pointer;
     box-sizing: border-box;
@@ -760,8 +760,8 @@ export const roomPopupStyles = `
   }
 
   .popup-garage-item-icon {
-    width: 50px;
-    height: 50px;
+    width: 38px;
+    height: 38px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -778,7 +778,7 @@ export const roomPopupStyles = `
   }
 
   .popup-garage-item-icon ha-icon {
-    --mdc-icon-size: 22px;
+    --mdc-icon-size: 18px;
   }
 
   .popup-garage-item-header.open .popup-garage-item-icon ha-icon {
@@ -828,8 +828,8 @@ export const roomPopupStyles = `
   }
 
   .popup-garage-control-btn {
-    width: 36px;
-    height: 36px;
+    width: 28px;
+    height: 28px;
     border: none;
     border-radius: 50%;
     background: var(--dv-white);
@@ -845,7 +845,7 @@ export const roomPopupStyles = `
   }
 
   .popup-garage-control-btn ha-icon {
-    --mdc-icon-size: 20px;
+    --mdc-icon-size: 16px;
     color: var(--dv-gray800);
   }
 


### PR DESCRIPTION
## Summary

Fixes #99 — Garage items in room popup were 68px tall vs 42px for motion/window chips.
Fixes #100 — Show release version at bottom of every page.

## Changes

### Garage height normalization
- Item height: 68px → 46px
- Icon circle: 50px → 38px
- Control buttons: 36px → 28px
- Icons scaled proportionally

### Version footer
- Shows current version (e.g. v1.0.27) centered at bottom
- 10px font, muted color, subtle opacity
- Visible on all views