### PR TITLE
fix: replace hardcoded German strings with i18n translations

### DIFF
--- a/custom_components/dashview/frontend/constants/index.js
+++ b/custom_components/dashview/frontend/constants/index.js
@@ -3,6 +3,8 @@
  * Centralized constants for entity types, states, icons, and configuration
  */
 
+import { t } from '../utils/i18n.js';
+
 // Entity domains
 export const DOMAINS = {
   LIGHT: 'light',
@@ -334,17 +336,22 @@ export const ENTITY_CONFIGS = {
       return ICONS.LOCK_LOCKED;
     },
     getState: (entity) => {
-      if (entity.state === STATES.LOCKED) return 'Verriegelt';
-      if (entity.state === STATES.UNLOCKED) return 'Entriegelt';
-      if (entity.state === STATES.LOCKING) return 'Verriegelt...';
-      if (entity.state === STATES.UNLOCKING) return 'Entriegelt...';
+      if (entity.state === STATES.LOCKED) return t('lock.locked');
+      if (entity.state === STATES.UNLOCKED) return t('lock.unlocked');
+      if (entity.state === STATES.LOCKING) return t('lock.locking');
+      if (entity.state === STATES.UNLOCKING) return t('lock.unlocking');
       return entity.state;
     },
     isActive: (entity) => entity.state === STATES.UNLOCKED,
   },
 };
 
-// Weather condition translations (German)
+// Weather condition translations (via i18n)
+export function getWeatherConditionText(condition) {
+  return t(`weather.conditions.${condition}`, condition);
+}
+
+// Legacy mapping — kept for backward compatibility, prefer getWeatherConditionText()
 export const WEATHER_CONDITIONS = {
   'clear-night': 'Klare Nacht',
   'cloudy': 'Bewölkt',

--- a/custom_components/dashview/frontend/features/admin/shared.js
+++ b/custom_components/dashview/frontend/features/admin/shared.js
@@ -414,21 +414,21 @@ export function renderSecurityPopupContent(panel, html) {
         @click=${() => panel._activeSecurityTab = 'windows'}
       >
         <ha-icon icon="mdi:window-open"></ha-icon>
-        <span>${openWindowsCount} von ${enabledWindows.length}</span>
+        <span>${openWindowsCount} ${t('common.options.of', 'of')} ${enabledWindows.length}</span>
       </button>
       <button
         class="security-tab ${panel._activeSecurityTab === 'garage' ? 'active' : ''}"
         @click=${() => panel._activeSecurityTab = 'garage'}
       >
         <ha-icon icon="mdi:garage"></ha-icon>
-        <span>${openGaragesCount} von ${enabledGarages.length}</span>
+        <span>${openGaragesCount} ${t('common.options.of', 'of')} ${enabledGarages.length}</span>
       </button>
       <button
         class="security-tab ${panel._activeSecurityTab === 'motion' ? 'active' : ''}"
         @click=${() => panel._activeSecurityTab = 'motion'}
       >
         <ha-icon icon="mdi:motion-sensor"></ha-icon>
-        <span>${activeMotionCount} von ${enabledMotion.length}</span>
+        <span>${activeMotionCount} ${t('common.options.of', 'of')} ${enabledMotion.length}</span>
       </button>
     </div>
 
@@ -436,12 +436,12 @@ export function renderSecurityPopupContent(panel, html) {
     ${panel._activeSecurityTab === 'windows' ? html`
       ${enabledWindows.length === 0 ? html`
         <div class="security-empty-state">
-          Keine Fenster in der Admin-Konfiguration aktiviert.
+          ${t('security.windows.empty', 'No windows enabled in admin configuration.')}
         </div>
       ` : html`
         <!-- Open Windows -->
         ${enabledWindows.filter(w => w.isOpen).length > 0 ? html`
-          <h3 class="security-subsection-title">Offene Fenster</h3>
+          <h3 class="security-subsection-title">${t('security.windows.open', 'Open Windows')}</h3>
           <div class="security-entity-list">
             ${enabledWindows.filter(w => w.isOpen).map(w => renderEntityCard(w, 'window'))}
           </div>
@@ -449,7 +449,7 @@ export function renderSecurityPopupContent(panel, html) {
 
         <!-- Closed Windows -->
         ${enabledWindows.filter(w => !w.isOpen).length > 0 ? html`
-          <h3 class="security-subsection-title">Geschlossene Fenster</h3>
+          <h3 class="security-subsection-title">${t('security.windows.closed', 'Closed Windows')}</h3>
           <div class="security-entity-list">
             ${enabledWindows.filter(w => !w.isOpen).map(w => renderEntityCard(w, 'window'))}
           </div>
@@ -461,12 +461,12 @@ export function renderSecurityPopupContent(panel, html) {
     ${panel._activeSecurityTab === 'garage' ? html`
       ${enabledGarages.length === 0 ? html`
         <div class="security-empty-state">
-          Keine Garagentore in der Admin-Konfiguration aktiviert.
+          ${t('security.garages.empty', 'No garage doors enabled in admin configuration.')}
         </div>
       ` : html`
         <!-- Open Garages -->
         ${enabledGarages.filter(g => g.isOpen).length > 0 ? html`
-          <h3 class="security-subsection-title">Offene Garagentore</h3>
+          <h3 class="security-subsection-title">${t('security.garages.open', 'Open Garage Doors')}</h3>
           <div class="security-entity-list">
             ${enabledGarages.filter(g => g.isOpen).map(g => renderEntityCard(g, 'garage'))}
           </div>
@@ -474,7 +474,7 @@ export function renderSecurityPopupContent(panel, html) {
 
         <!-- Closed Garages -->
         ${enabledGarages.filter(g => !g.isOpen).length > 0 ? html`
-          <h3 class="security-subsection-title">Geschlossene Garagentore</h3>
+          <h3 class="security-subsection-title">${t('security.garages.closed', 'Closed Garage Doors')}</h3>
           <div class="security-entity-list">
             ${enabledGarages.filter(g => !g.isOpen).map(g => renderEntityCard(g, 'garage'))}
           </div>
@@ -486,12 +486,12 @@ export function renderSecurityPopupContent(panel, html) {
     ${panel._activeSecurityTab === 'motion' ? html`
       ${enabledMotion.length === 0 ? html`
         <div class="security-empty-state">
-          Keine Bewegungsmelder in der Admin-Konfiguration aktiviert.
+          ${t('security.motion.empty', 'No motion sensors enabled in admin configuration.')}
         </div>
       ` : html`
         <!-- Active Motion -->
         ${enabledMotion.filter(m => m.isActive).length > 0 ? html`
-          <h3 class="security-subsection-title">Bewegung erkannt</h3>
+          <h3 class="security-subsection-title">${t('security.motion.detected', 'Motion Detected')}</h3>
           <div class="security-entity-list">
             ${enabledMotion.filter(m => m.isActive).map(m => renderEntityCard(m, 'motion'))}
           </div>
@@ -499,7 +499,7 @@ export function renderSecurityPopupContent(panel, html) {
 
         <!-- Inactive Motion -->
         ${enabledMotion.filter(m => !m.isActive).length > 0 ? html`
-          <h3 class="security-subsection-title">Keine Bewegung</h3>
+          <h3 class="security-subsection-title">${t('security.motion.none', 'No Motion')}</h3>
           <div class="security-entity-list">
             ${enabledMotion.filter(m => !m.isActive).map(m => renderEntityCard(m, 'motion'))}
           </div>

--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -153,7 +153,8 @@
       "other_devices": "Weitere Geräte",
       "devices": "Geräte",
       "locks": "Schlösser",
-      "batteries": "Batterien"
+      "batteries": "Batterien",
+      "batteries_ok": "Alle Batterien in Ordnung"
     },
     "errors": {
       "no_data": "Keine Daten verfügbar",
@@ -167,7 +168,8 @@
       "no_cards_configured": "Keine Karten konfiguriert. Konfiguriere Karten im Admin-Bereich unter \"Etagen-Karten\".",
       "no_sensors_selected": "Keine Sensoren ausgewählt",
       "no_devices_enabled": "Keine Geräte aktiviert.",
-      "no_lights_enabled": "Keine Lichter in der Admin-Konfiguration aktiviert."
+      "no_lights_enabled": "Keine Lichter in der Admin-Konfiguration aktiviert.",
+      "no_windows_enabled": "Keine Fenster in der Admin-Konfiguration aktiviert."
     },
     "popups": {
       "lights": {
@@ -251,6 +253,23 @@
       "low": "Gering",
       "moderate": "Mäßig",
       "high": "Stark"
+    },
+    "conditions": {
+      "sunny": "Sonnig",
+      "clear-night": "Klare Nacht",
+      "partlycloudy": "Teilweise bewölkt",
+      "cloudy": "Bewölkt",
+      "rainy": "Regnerisch",
+      "pouring": "Starkregen",
+      "lightning": "Gewitter",
+      "lightning-rainy": "Gewitter mit Regen",
+      "windy": "Windig",
+      "windy-variant": "Windig",
+      "fog": "Nebel",
+      "hail": "Hagel",
+      "snowy": "Schnee",
+      "snowy-rainy": "Schneeregen",
+      "exceptional": "Außergewöhnlich"
     }
   },
   "media": {
@@ -260,7 +279,8 @@
     "off": "Ausgeschaltet",
     "idle": "Bereit",
     "playing": "Spielt",
-    "paused": "Pausiert"
+    "paused": "Pausiert",
+    "standby": "Bereit"
   },
   "status": {
     "water": {
@@ -945,6 +965,23 @@
       "edit": "Bearbeiten",
       "ready": "Alles bereit!",
       "readyDesc": "Klicke Fertig um die Einrichtung abzuschließen und dein Dashboard zu nutzen."
+    }
+  },
+  "security": {
+    "windows": {
+      "empty": "Keine Fenster in der Admin-Konfiguration aktiviert.",
+      "open": "Offene Fenster",
+      "closed": "Geschlossene Fenster"
+    },
+    "garages": {
+      "empty": "Keine Garagentore in der Admin-Konfiguration aktiviert.",
+      "open": "Offene Garagentore",
+      "closed": "Geschlossene Garagentore"
+    },
+    "motion": {
+      "empty": "Keine Bewegungsmelder in der Admin-Konfiguration aktiviert.",
+      "detected": "Bewegung erkannt",
+      "none": "Keine Bewegung"
     }
   }
 }

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -153,7 +153,8 @@
       "other_devices": "Other Devices",
       "devices": "Devices",
       "locks": "Locks",
-      "batteries": "Batteries"
+      "batteries": "Batteries",
+      "batteries_ok": "All batteries OK"
     },
     "errors": {
       "no_data": "No data available",
@@ -167,7 +168,8 @@
       "no_cards_configured": "No cards configured. Configure cards in the admin area under \"Floor Cards\".",
       "no_sensors_selected": "No sensors selected",
       "no_devices_enabled": "No devices enabled.",
-      "no_lights_enabled": "No lights enabled in admin configuration."
+      "no_lights_enabled": "No lights enabled in admin configuration.",
+      "no_windows_enabled": "No windows enabled in admin configuration."
     },
     "popups": {
       "lights": {
@@ -251,6 +253,23 @@
       "low": "Low",
       "moderate": "Moderate",
       "high": "High"
+    },
+    "conditions": {
+      "sunny": "Sunny",
+      "clear-night": "Clear night",
+      "partlycloudy": "Partly cloudy",
+      "cloudy": "Cloudy",
+      "rainy": "Rainy",
+      "pouring": "Heavy rain",
+      "lightning": "Thunderstorm",
+      "lightning-rainy": "Thunderstorm with rain",
+      "windy": "Windy",
+      "windy-variant": "Windy",
+      "fog": "Fog",
+      "hail": "Hail",
+      "snowy": "Snow",
+      "snowy-rainy": "Sleet",
+      "exceptional": "Exceptional"
     }
   },
   "media": {
@@ -260,7 +279,8 @@
     "off": "Off",
     "idle": "Ready",
     "playing": "Playing",
-    "paused": "Paused"
+    "paused": "Paused",
+    "standby": "Standby"
   },
   "status": {
     "water": {
@@ -774,7 +794,9 @@
       "emptyHint": "Create areas and assign them to floors in Home Assistant.",
       "noRooms": "No rooms assigned to this floor",
       "rooms": "rooms",
-      "hint": "Tip: Rooms appear in this order within each floor view."
+      "hint": "Tip: Rooms appear in this order within each floor view.",
+      "unassigned": "Unassigned Rooms",
+      "assignInHA": "Assign in HA"
     },
     "labels": {
       "title": "Set Up Your Labels",
@@ -790,7 +812,11 @@
       "enableAll": "Enable All",
       "disableAll": "Disable All",
       "roomsEnabled": "{{count}} rooms enabled",
-      "hint": "Tip: Only enabled rooms will appear on your dashboard. You can change this later in Admin settings."
+      "hint": "Tip: Only enabled rooms will appear on your dashboard. You can change this later in Admin settings.",
+      "enabled": "Enabled",
+      "total": "Total",
+      "floors": "Floors",
+      "entities": "Entities"
     },
     "floorCards": {
       "title": "Configure Floor Cards",
@@ -815,6 +841,147 @@
       "edit": "Edit",
       "ready": "You're All Set!",
       "readyDesc": "Click Finish to complete setup and start using your dashboard."
+    }
+  },
+  "security": {
+    "windows": {
+      "empty": "No windows enabled in admin configuration.",
+      "open": "Open Windows",
+      "closed": "Closed Windows"
+    },
+    "garages": {
+      "empty": "No garage doors enabled in admin configuration.",
+      "open": "Open Garage Doors",
+      "closed": "Closed Garage Doors"
+    },
+    "motion": {
+      "empty": "No motion sensors enabled in admin configuration.",
+      "detected": "Motion Detected",
+      "none": "No Motion"
+    }
+  },
+  "onboarding": {
+    "title": "Setup Wizard",
+    "subtitle": "Let's get Dashview configured for your home",
+    "step": "Step",
+    "complete": "complete",
+    "back": "Back",
+    "next": "Next",
+    "skip": "Skip",
+    "finish": "Finish Setup",
+    "stepPlaceholder": "Step content will be implemented here.",
+    "steps": {
+      "welcome": "Welcome",
+      "floors": "Floors",
+      "rooms": "Rooms",
+      "entities": "Entities",
+      "layout": "Layout",
+      "weather": "Weather",
+      "review": "Review"
+    },
+    "welcome": {
+      "title": "Welcome to Dashview!",
+      "subtitle": "Your new smart home dashboard for Home Assistant. Let's set it up together.",
+      "feature1Title": "Beautiful Dashboard",
+      "feature1Desc": "A clean, intuitive dashboard designed for touch screens and wall tablets.",
+      "feature2Title": "Floor Organization",
+      "feature2Desc": "Organize your rooms by floor for easy navigation throughout your home.",
+      "feature3Title": "Quick Controls",
+      "feature3Desc": "Control lights, covers, and devices with simple taps and swipes.",
+      "feature4Title": "Weather Integration",
+      "feature4Desc": "View current weather and forecasts directly on your dashboard.",
+      "ctaText": "Click \"Next\" to start configuring"
+    },
+    "floors": {
+      "title": "Set Up Floors",
+      "desc": "Create floors for your home and drag to reorder them.",
+      "empty": "No floors yet. Add your first floor above to get started.",
+      "placeholder": "Enter floor name (e.g. Ground Floor, Upper Floor)",
+      "addFloor": "Add Floor",
+      "creating": "Creating...",
+      "deleting": "Deleting...",
+      "rooms": "Rooms",
+      "minRequired": "At least one floor is required to continue.",
+      "deleteFloor": "Delete Floor",
+      "cannotDeleteLast": "The last floor cannot be deleted",
+      "confirmDeleteTitle": "Delete floor?",
+      "confirmDeleteMessage": "Do you really want to delete",
+      "confirmDeleteWarning": "This floor has {count} assigned rooms. They will become unassigned.",
+      "errorCreate": "Could not create floor. Please try again.",
+      "errorDelete": "Could not delete floor. Please try again.",
+      "errorDeleteLast": "The last floor cannot be deleted.",
+      "hint": "Tip: Drag floors to set the display order on your dashboard. Common names: Ground Floor, Upper Floor, Basement, Attic."
+    },
+    "rooms": {
+      "title": "Assign Rooms to Floors",
+      "desc": "Assign each room (area) to a floor. Use the dropdown to change.",
+      "empty": "No areas found in Home Assistant. Create areas under Settings → Areas & Zones.",
+      "unassigned": "Unassigned",
+      "unassignedFloor": "Unassigned Rooms",
+      "rooms": "Rooms",
+      "noRooms": "No rooms assigned to this floor",
+      "hint": "Tip: You can also manage areas in Home Assistant under Settings → Areas & Zones"
+    },
+    "entities": {
+      "title": "Select Devices",
+      "desc": "Choose devices for your dashboard. Devices are grouped by room.",
+      "searchPlaceholder": "Search devices...",
+      "selectAll": "All",
+      "selectNone": "None",
+      "selectedCount": "{{count}} selected",
+      "suggested": "Suggested",
+      "noEntities": "No devices found",
+      "noMatchingEntities": "No matching devices",
+      "noRoomEntities": "No devices in this room",
+      "unassignedRoom": "Unassigned Devices",
+      "summary": "{{selected}} of {{total}} devices selected",
+      "hint": "Tip: Suggested devices (lights, climate, covers) are pre-selected for convenience",
+      "enableSuggested": "Enable suggested",
+      "selected": "Selected",
+      "total": "Total",
+      "rooms": "Rooms",
+      "noResults": "No devices matching your search."
+    },
+    "layout": {
+      "title": "Arrange Floor Cards",
+      "desc": "Set the display order of floor cards on the dashboard.",
+      "noFloors": "No floors configured. Go back to add floors.",
+      "room": "Room",
+      "rooms": "Rooms",
+      "preview": "Preview",
+      "hint": "You can change the order later in the Admin area under Layout."
+    },
+    "weather": {
+      "title": "Weather Display",
+      "desc": "Choose a weather entity to show forecasts on the dashboard.",
+      "optional": "Optional — you can skip this step",
+      "noWeather": "Don't show weather on the dashboard",
+      "noEntities": "No weather entities found. Install a weather integration in Home Assistant.",
+      "preview": "Preview"
+    },
+    "review": {
+      "title": "Review Setup",
+      "desc": "Here's a summary of your configuration. You can edit any section before finishing.",
+      "floors": "Floors",
+      "floor": "Floor",
+      "floorsPlural": "Floors",
+      "configured": "configured",
+      "rooms": "Rooms",
+      "room": "Room",
+      "roomsPlural": "Rooms",
+      "assigned": "assigned",
+      "entities": "Entities",
+      "entity": "Entity",
+      "entitiesPlural": "Entities",
+      "selected": "selected",
+      "weather": "Weather",
+      "noWeather": "Not configured (optional)",
+      "layout": "Layout",
+      "layoutCustom": "Custom floor order",
+      "layoutDefault": "Default floor order",
+      "edit": "Edit",
+      "ready": "All set!",
+      "readyDesc": "Your dashboard is configured and ready to use."
     }
   }
 }

--- a/custom_components/dashview/frontend/services/weather-service.js
+++ b/custom_components/dashview/frontend/services/weather-service.js
@@ -97,12 +97,12 @@ export function getWeather(hass, weatherEntity) {
 }
 
 /**
- * Translate weather condition to German
+ * Translate weather condition using i18n
  * @param {string} state - Weather condition state
  * @returns {string} Translated condition
  */
 export function translateWeatherCondition(state) {
-  return WEATHER_TRANSLATIONS[state] || state;
+  return t(`weather.conditions.${state}`, state);
 }
 
 /**

--- a/custom_components/dashview/frontend/utils/icons.js
+++ b/custom_components/dashview/frontend/utils/icons.js
@@ -3,6 +3,8 @@
  * Functions for getting icons for entities, areas, floors, and weather
  */
 
+import { t } from './i18n.js';
+
 /**
  * Get icon for an area (room)
  * @param {Object} area - Area object from Home Assistant
@@ -72,27 +74,10 @@ export function getWeatherIcon(state) {
 }
 
 /**
- * Translate weather condition to German
+ * Translate weather condition using i18n
  * @param {string} state - Weather condition state
  * @returns {string} Translated condition string
  */
 export function translateWeatherCondition(state) {
-  const translations = {
-    "sunny": "Sonnig",
-    "clear-night": "Klar",
-    "partlycloudy": "Teilweise bewölkt",
-    "cloudy": "Bewölkt",
-    "rainy": "Regnerisch",
-    "pouring": "Starkregen",
-    "lightning": "Gewitter",
-    "lightning-rainy": "Gewitter mit Regen",
-    "windy": "Windig",
-    "windy-variant": "Windig",
-    "fog": "Nebel",
-    "hail": "Hagel",
-    "snowy": "Schnee",
-    "snowy-rainy": "Schneeregen",
-    "exceptional": "Außergewöhnlich"
-  };
-  return translations[state] || state;
+  return t(`weather.conditions.${state}`, state);
 }


### PR DESCRIPTION
## Summary

Fixes #112 — English users see German fallback strings.

### Changes

**Locale files:**
- `en.json`: Added all missing keys — `onboarding` section (entire tree), `security` section (window/garage/motion popup strings), `weather.conditions` (15 weather states), `media.standby`, `ui.errors.no_windows_enabled`, `ui.sections.batteries_ok`
- `de.json`: Added matching new keys (`weather.conditions`, `security`, `media.standby`, etc.)
- **Both locale files now have zero key gaps** vs each other

**Source files (hardcoded German → i18n):**
- `constants/index.js`: Lock states (Verriegelt/Entriegelt) → `t('lock.locked')` etc.
- `utils/icons.js`: Weather condition translation → `t('weather.conditions.*')`
- `services/weather-service.js`: Same weather translation fix
- `features/admin/shared.js`: Security popup headers & empty states (9 hardcoded German strings → `t()` calls), tab counters (`von` → `t('common.options.of')`)

### Testing
- Test suite: 1114 passing (14 pre-existing failures unchanged)
- No new test regressions