### PR TITLE
fix: make locks section collapsible in room popup (#105)

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -281,6 +281,7 @@ if (typeof structuredClone === 'undefined') {
         _popupCoverExpanded: { type: Boolean },
         _popupGarageExpanded: { type: Boolean },
         _popupLightExpanded: { type: Boolean },
+        _popupLockExpanded: { type: Boolean },
         _popupTVExpanded: { type: Boolean },
         _popupMediaExpanded: { type: Boolean },
         _popupThermostatExpanded: { type: Boolean },
@@ -458,6 +459,7 @@ if (typeof structuredClone === 'undefined') {
       this._popupCoverExpanded = false;
       this._popupGarageExpanded = false;
       this._popupLightExpanded = true;
+      this._popupLockExpanded = true;
       this._popupMediaExpanded = true;
       this._popupThermostatExpanded = true;
       this._popupRoofWindowExpanded = true;
@@ -2296,6 +2298,7 @@ if (typeof structuredClone === 'undefined') {
 
     _togglePopupCoverExpanded() { this._toggleBoolProp('_popupCoverExpanded'); }
     _togglePopupGarageExpanded() { this._toggleBoolProp('_popupGarageExpanded'); }
+    _togglePopupLockExpanded() { this._toggleBoolProp('_popupLockExpanded'); }
     _togglePopupThermostatExpanded() { this._toggleBoolProp('_popupThermostatExpanded'); }
 
     /**

--- a/custom_components/dashview/frontend/features/popups/room-popup.js
+++ b/custom_components/dashview/frontend/features/popups/room-popup.js
@@ -800,13 +800,13 @@ function renderLockSection(component, html, areaId) {
 
   return html`
     <div class="popup-lock-section">
-      <div class="popup-lock-header">
+      <div class="popup-lock-header" @click=${component._togglePopupLockExpanded}>
         <ha-icon icon="mdi:lock"></ha-icon>
         <span class="popup-lock-title">${t('ui.sections.locks')}</span>
         <span class="popup-lock-count">${unlockedCount > 0 ? t('lock.count_unlocked', { count: unlockedCount }) : t('lock.all_locked')}</span>
       </div>
 
-      <div class="popup-lock-content">
+      <div class="popup-lock-content ${component._popupLockExpanded ? 'expanded' : ''}"
         ${locks.map(lock => html`
           <div class="popup-lock-item ${lock.state === 'unlocked' ? 'unlocked' : 'locked'}"
                @click=${() => component._toggleLock(lock.entity_id)}>

--- a/custom_components/dashview/frontend/styles/popups/room.js
+++ b/custom_components/dashview/frontend/styles/popups/room.js
@@ -862,6 +862,7 @@ export const roomPopupStyles = `
     align-items: center;
     padding: 6px 0;
     min-height: 46px;
+    cursor: pointer;
   }
 
   .popup-lock-header ha-icon {
@@ -885,6 +886,13 @@ export const roomPopupStyles = `
   }
 
   .popup-lock-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height var(--dv-transition-slow) ease;
+  }
+
+  .popup-lock-content.expanded {
+    max-height: 500px;
     display: flex;
     flex-direction: column;
     gap: 4px;


### PR DESCRIPTION
## Summary

Make the Locks section in the room popup collapsible (tap header to expand/collapse), matching the behavior of all other sections (Covers, Media, Garages, Lights, etc.).

Closes #105

## Changes

**dashview-panel.js:**
- Added `_popupLockExpanded` boolean property (default: `true`)
- Added `_togglePopupLockExpanded()` toggle method

**room-popup.js:**
- Wired lock header `@click` to `_togglePopupLockExpanded`
- Added `expanded` class toggle on `.popup-lock-content`

**styles/popups/room.js:**
- Added collapse/expand CSS for `.popup-lock-content` (max-height transition pattern matching other sections)
- Added `cursor: pointer` to `.popup-lock-header`

## Note
Thermostat section is intentionally left as-is per maintainer decision — only locks are addressed in this PR.