### PR TITLE
fix: remove hardcoded washer entity ID fallback

### DIFF
--- a/custom_components/dashview/frontend/services/status-service.js
+++ b/custom_components/dashview/frontend/services/status-service.js
@@ -21,8 +21,10 @@ import { t } from '../utils/i18n.js';
 export function getWasherStatus(hass, infoTextConfig) {
   if (!hass || !infoTextConfig.washer?.enabled) return null;
 
-  const entityId = infoTextConfig.washer.entity || "sensor.waschmaschine_operation_state";
-  const finishTimeEntityId = infoTextConfig.washer.finishTimeEntity || "sensor.waschmaschine_programme_finish_time";
+  const entityId = infoTextConfig.washer.entity;
+  const finishTimeEntityId = infoTextConfig.washer.finishTimeEntity;
+
+  if (!entityId) return null;
 
   const operationState = hass.states[entityId];
   const finishTime = finishTimeEntityId ? hass.states[finishTimeEntityId] : null;


### PR DESCRIPTION
Fixes #118

Removes hardcoded `sensor.waschmaschine_operation_state` and `sensor.waschmaschine_programme_finish_time` fallbacks from `getWasherStatus()`. 

Now returns `null` when no entity is configured — consistent with `getDishwasherStatus()` and `getDryerStatus()`.

**Change:** 1 file, +4/-2 lines.