### PR TITLE
fix: add long-press to open details for all entity types

### DIFF
--- a/custom_components/dashview/frontend/features/popups/room-popup.js
+++ b/custom_components/dashview/frontend/features/popups/room-popup.js
@@ -623,9 +623,27 @@ function renderCoverSection(component, html, areaId) {
         <!-- Individual covers -->
         ${covers.map(cover => {
           const displayPosition = cover.invertPosition ? (100 - (cover.position || 0)) : (cover.position || 0);
+          const longPress = createLongPressHandlers(
+            null,
+            () => {
+              component._closeRoomPopup();
+              requestAnimationFrame(() => {
+                openMoreInfo(component, cover.entity_id);
+              });
+            }
+          );
+
           return html`
           <div class="popup-cover-item">
-            <span class="popup-cover-item-name">${cover.name}</span>
+            <span class="popup-cover-item-name"
+                  style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+                  @touchstart=${longPress.onTouchStart}
+                  @touchmove=${longPress.onTouchMove}
+                  @touchend=${longPress.onTouchEnd}
+                  @touchcancel=${longPress.onTouchCancel}
+                  @mousedown=${longPress.onMouseDown}
+                  @mouseup=${longPress.onMouseUp}
+                  @mouseleave=${longPress.onMouseLeave}>${cover.name}</span>
             <div class="popup-cover-slider"
               @click=${(e) => component._handleCoverSliderClick(e, cover.entity_id)}
               @touchstart=${(e) => component._handleCoverSliderTouchStart(e, cover.entity_id, null)}
@@ -677,9 +695,27 @@ function renderMediaPlayer(component, html, player) {
   const isActive = isPlaying || isPaused;
   const volumePercent = player.volume_level !== undefined ? Math.round(player.volume_level * 100) : 0;
 
+  const longPress = createLongPressHandlers(
+    null,
+    () => {
+      component._closeRoomPopup();
+      requestAnimationFrame(() => {
+        openMoreInfo(component, player.entity_id);
+      });
+    }
+  );
+
   return html`
     <div class="popup-media-player">
-      <div class="popup-media-player-name">${player.name}</div>
+      <div class="popup-media-player-name"
+           style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+           @touchstart=${longPress.onTouchStart}
+           @touchmove=${longPress.onTouchMove}
+           @touchend=${longPress.onTouchEnd}
+           @touchcancel=${longPress.onTouchCancel}
+           @mousedown=${longPress.onMouseDown}
+           @mouseup=${longPress.onMouseUp}
+           @mouseleave=${longPress.onMouseLeave}>${player.name}</div>
 
       ${isActive ? html`
         <!-- Artwork -->
@@ -767,9 +803,27 @@ function renderTVSection(component, html, areaId) {
       </div>
 
       <div class="popup-tv-content ${component._popupTVExpanded ? 'expanded' : ''}">
-        ${tvs.map(tv => html`
+        ${tvs.map(tv => {
+          const longPress = createLongPressHandlers(
+            () => component._toggleTV(tv.entity_id),
+            () => {
+              component._closeRoomPopup();
+              requestAnimationFrame(() => {
+                openMoreInfo(component, tv.entity_id);
+              });
+            }
+          );
+
+          return html`
           <div class="popup-tv-item ${tv.state === 'on' ? 'on' : 'off'}"
-               @click=${() => component._toggleTV(tv.entity_id)}>
+               style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+               @touchstart=${longPress.onTouchStart}
+               @touchmove=${longPress.onTouchMove}
+               @touchend=${longPress.onTouchEnd}
+               @touchcancel=${longPress.onTouchCancel}
+               @mousedown=${longPress.onMouseDown}
+               @mouseup=${longPress.onMouseUp}
+               @mouseleave=${longPress.onMouseLeave}>
             <div class="popup-tv-item-icon ${tv.entityPicture ? 'has-image' : ''}">
               ${tv.entityPicture ? html`
                 <img class="popup-tv-item-image" src="${tv.entityPicture}" alt="">
@@ -782,7 +836,7 @@ function renderTVSection(component, html, areaId) {
               <span class="popup-tv-item-state">${tv.name}</span>
             </div>
           </div>
-        `)}
+        `})}
       </div>
     </div>
   `;
@@ -807,9 +861,27 @@ function renderLockSection(component, html, areaId) {
       </div>
 
       <div class="popup-lock-content">
-        ${locks.map(lock => html`
+        ${locks.map(lock => {
+          const longPress = createLongPressHandlers(
+            () => component._toggleLock(lock.entity_id),
+            () => {
+              component._closeRoomPopup();
+              requestAnimationFrame(() => {
+                openMoreInfo(component, lock.entity_id);
+              });
+            }
+          );
+
+          return html`
           <div class="popup-lock-item ${lock.state === 'unlocked' ? 'unlocked' : 'locked'}"
-               @click=${() => component._toggleLock(lock.entity_id)}>
+               style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+               @touchstart=${longPress.onTouchStart}
+               @touchmove=${longPress.onTouchMove}
+               @touchend=${longPress.onTouchEnd}
+               @touchcancel=${longPress.onTouchCancel}
+               @mousedown=${longPress.onMouseDown}
+               @mouseup=${longPress.onMouseUp}
+               @mouseleave=${longPress.onMouseLeave}>
             <div class="popup-lock-item-icon">
               <ha-icon icon="${lock.icon}"></ha-icon>
             </div>
@@ -818,7 +890,7 @@ function renderLockSection(component, html, areaId) {
               <span class="popup-lock-item-state">${lock.state === 'locked' ? t('lock.locked') : lock.state === 'unlocked' ? t('lock.unlocked') : lock.state}</span>
             </div>
           </div>
-        `)}
+        `})}
       </div>
     </div>
   `;
@@ -843,13 +915,32 @@ function renderGarageSection(component, html, areaId) {
       </div>
 
       <div class="popup-garage-content ${component._popupGarageExpanded ? 'expanded' : ''}">
-        ${garages.map(garage => html`
+        ${garages.map(garage => {
+          const longPress = createLongPressHandlers(
+            null,
+            () => {
+              component._closeRoomPopup();
+              requestAnimationFrame(() => {
+                openMoreInfo(component, garage.entity_id);
+              });
+            }
+          );
+
+          return html`
           <div class="popup-garage-item">
             <div class="popup-garage-item-header ${garage.state === 'open' ? 'open' : 'closed'}">
               <div class="popup-garage-item-icon">
                 <ha-icon icon="${garage.state === 'open' ? 'mdi:garage-open' : 'mdi:garage'}"></ha-icon>
               </div>
-              <div class="popup-garage-item-info">
+              <div class="popup-garage-item-info"
+                   style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+                   @touchstart=${longPress.onTouchStart}
+                   @touchmove=${longPress.onTouchMove}
+                   @touchend=${longPress.onTouchEnd}
+                   @touchcancel=${longPress.onTouchCancel}
+                   @mousedown=${longPress.onMouseDown}
+                   @mouseup=${longPress.onMouseUp}
+                   @mouseleave=${longPress.onMouseLeave}>
                 <span class="popup-garage-item-name">${garage.name}</span>
                 <span class="popup-garage-item-last-changed">${component._formatGarageLastChanged(garage.last_changed)}</span>
               </div>
@@ -863,7 +954,7 @@ function renderGarageSection(component, html, areaId) {
               </div>
             </div>
           </div>
-        `)}
+        `})}
       </div>
     </div>
   `;
@@ -917,8 +1008,26 @@ function renderDeviceCard(component, html, appliance) {
   if (status.isError) classes.push('error');
   if (status.isUnavailable) classes.push('unavailable');
 
+  const longPress = createLongPressHandlers(
+    null,
+    () => {
+      component._closeRoomPopup();
+      requestAnimationFrame(() => {
+        openMoreInfo(component, appliance.entity_id);
+      });
+    }
+  );
+
   return html`
-    <div class="${classes.join(' ')}">
+    <div class="${classes.join(' ')}"
+         style="cursor: pointer; user-select: none; -webkit-user-select: none;"
+         @touchstart=${longPress.onTouchStart}
+         @touchmove=${longPress.onTouchMove}
+         @touchend=${longPress.onTouchEnd}
+         @touchcancel=${longPress.onTouchCancel}
+         @mousedown=${longPress.onMouseDown}
+         @mouseup=${longPress.onMouseUp}
+         @mouseleave=${longPress.onMouseLeave}>
       <div class="popup-device-card-icon">
         <ha-icon icon="${appliance.icon}"></ha-icon>
       </div>


### PR DESCRIPTION
## Summary

Closes #103

Long-press (hold 500ms) now opens the Home Assistant `more-info` details dialog for **all** entity types in the room popup — previously this only worked on lights.

## Entity types with long-press support added

| Entity Type | Long-press target | Tap behavior |
|---|---|---|
| **TV** | Entire item row | Toggle on/off (unchanged) |
| **Lock** | Entire item row | Toggle lock/unlock (unchanged) |
| **Cover** | Cover name label | No tap action (slider unchanged) |
| **Media Player** | Player name label | No tap action (controls unchanged) |
| **Garage** | Info area (name + last changed) | No tap action (open/close buttons unchanged) |
| **Appliance** | Entire device card | No tap action |

## How it works

Reuses the existing `createLongPressHandlers` utility (from `utils/long-press-handlers.js`) that was already powering light long-press. Each handler:
1. Closes the room popup
2. Fires `openMoreInfo` to open HA's native `more-info` dialog for that entity

Touch support (touchstart/touchmove/touchend/touchcancel) and mouse support (mousedown/mouseup/mouseleave) are both wired, with haptic feedback on long-press — identical to the lights implementation.

## Testing

- `npx vitest run` — 14 pre-existing failures, **no new failures**