### PR TITLE
feat: add quick action buttons for locks, TVs, garages, and media

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -2429,6 +2429,52 @@ if (typeof structuredClone === 'undefined') {
       });
     }
     _toggleAllRoomCovers(areaId, close) { this._setAllCoversPosition(areaId, close ? 100 : 0); }
+    _lockAllRoom(areaId) {
+      this._getEnabledLocksForRoom(areaId).forEach(l => {
+        try {
+          this.hass.callService('lock', 'lock', { entity_id: l.entity_id });
+        } catch (error) {
+          console.warn(`[Dashview] Lock error:`, error.message);
+          this._dispatchErrorEvent('room-popup:lockAll', l.entity_id, error);
+        }
+      });
+    }
+    _turnOffAllRoomTVs(areaId) {
+      this._getEnabledTVsForRoom(areaId).forEach(tv => {
+        try {
+          if (tv.state === 'on') {
+            this.hass.callService('media_player', 'turn_off', { entity_id: tv.entity_id });
+          }
+        } catch (error) {
+          console.warn(`[Dashview] TV off error:`, error.message);
+          this._dispatchErrorEvent('room-popup:tvsOff', tv.entity_id, error);
+        }
+      });
+    }
+    _closeAllRoomGarages(areaId) {
+      this._getEnabledGaragesForRoom(areaId).forEach(g => {
+        try {
+          if (g.state === 'open') {
+            this.hass.callService('cover', 'close_cover', { entity_id: g.entity_id });
+          }
+        } catch (error) {
+          console.warn(`[Dashview] Garage close error:`, error.message);
+          this._dispatchErrorEvent('room-popup:closeGarages', g.entity_id, error);
+        }
+      });
+    }
+    _stopAllRoomMedia(areaId) {
+      this._getEnabledMediaPlayersForRoom(areaId).forEach(mp => {
+        try {
+          if (mp.state === 'playing') {
+            this.hass.callService('media_player', 'media_stop', { entity_id: mp.entity_id });
+          }
+        } catch (error) {
+          console.warn(`[Dashview] Media stop error:`, error.message);
+          this._dispatchErrorEvent('room-popup:stopMedia', mp.entity_id, error);
+        }
+      });
+    }
     _handleCoverSliderClick(e, entityId) { this._setCoverPosition(entityId, this._getInvertedSliderPosition(e)); }
     _handleAllCoversSliderClick(e, areaId) { this._setAllCoversPosition(areaId, this._getInvertedSliderPosition(e));
     }

--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -2429,51 +2429,51 @@ if (typeof structuredClone === 'undefined') {
       });
     }
     _toggleAllRoomCovers(areaId, close) { this._setAllCoversPosition(areaId, close ? 100 : 0); }
-    _lockAllRoom(areaId) {
-      this._getEnabledLocksForRoom(areaId).forEach(l => {
+    async _lockAllRoom(areaId) {
+      for (const l of this._getEnabledLocksForRoom(areaId)) {
         try {
-          this.hass.callService('lock', 'lock', { entity_id: l.entity_id });
+          await this.hass.callService('lock', 'lock', { entity_id: l.entity_id });
         } catch (error) {
           console.warn(`[Dashview] Lock error:`, error.message);
           this._dispatchErrorEvent('room-popup:lockAll', l.entity_id, error);
         }
-      });
+      }
     }
-    _turnOffAllRoomTVs(areaId) {
-      this._getEnabledTVsForRoom(areaId).forEach(tv => {
+    async _turnOffAllRoomTVs(areaId) {
+      for (const tv of this._getEnabledTVsForRoom(areaId)) {
         try {
           if (tv.state === 'on') {
-            this.hass.callService('media_player', 'turn_off', { entity_id: tv.entity_id });
+            await this.hass.callService('media_player', 'turn_off', { entity_id: tv.entity_id });
           }
         } catch (error) {
           console.warn(`[Dashview] TV off error:`, error.message);
           this._dispatchErrorEvent('room-popup:tvsOff', tv.entity_id, error);
         }
-      });
+      }
     }
-    _closeAllRoomGarages(areaId) {
-      this._getEnabledGaragesForRoom(areaId).forEach(g => {
+    async _closeAllRoomGarages(areaId) {
+      for (const g of this._getEnabledGaragesForRoom(areaId)) {
         try {
           if (g.state === 'open') {
-            this.hass.callService('cover', 'close_cover', { entity_id: g.entity_id });
+            await this.hass.callService('cover', 'close_cover', { entity_id: g.entity_id });
           }
         } catch (error) {
           console.warn(`[Dashview] Garage close error:`, error.message);
           this._dispatchErrorEvent('room-popup:closeGarages', g.entity_id, error);
         }
-      });
+      }
     }
-    _stopAllRoomMedia(areaId) {
-      this._getEnabledMediaPlayersForRoom(areaId).forEach(mp => {
+    async _stopAllRoomMedia(areaId) {
+      for (const mp of this._getEnabledMediaPlayersForRoom(areaId)) {
         try {
           if (mp.state === 'playing') {
-            this.hass.callService('media_player', 'media_stop', { entity_id: mp.entity_id });
+            await this.hass.callService('media_player', 'media_stop', { entity_id: mp.entity_id });
           }
         } catch (error) {
           console.warn(`[Dashview] Media stop error:`, error.message);
           this._dispatchErrorEvent('room-popup:stopMedia', mp.entity_id, error);
         }
-      });
+      }
     }
     _handleCoverSliderClick(e, entityId) { this._setCoverPosition(entityId, this._getInvertedSliderPosition(e)); }
     _handleAllCoversSliderClick(e, areaId) { this._setAllCoversPosition(areaId, this._getInvertedSliderPosition(e));

--- a/custom_components/dashview/frontend/features/popups/room-popup.js
+++ b/custom_components/dashview/frontend/features/popups/room-popup.js
@@ -159,19 +159,28 @@ function renderChipsRow(component, html, areaId) {
 function renderQuickActions(component, html, areaId) {
   const lights = component._getEnabledLightsForRoom(areaId);
   const covers = component._getEnabledCoversForRoom(areaId);
+  const locks = component._getEnabledLocksForRoom(areaId);
+  const tvs = component._getEnabledTVsForRoom(areaId);
+  const garages = component._getEnabledGaragesForRoom(areaId);
+  const mediaPlayers = component._getEnabledMediaPlayersForRoom(areaId);
 
   // Get custom scene buttons assigned to this room
   const roomSceneButtons = (component._sceneButtons || []).filter(
     btn => btn.roomId === areaId && btn.entity
   );
 
-  if (lights.length === 0 && covers.length === 0 && roomSceneButtons.length === 0) return '';
+  if (lights.length === 0 && covers.length === 0 && locks.length === 0 && tvs.length === 0 && garages.length === 0 && mediaPlayers.length === 0 && roomSceneButtons.length === 0) return '';
 
   const lightsOnCount = lights.filter(l => l.state === 'on').length;
   const anyLightsOn = lightsOnCount > 0;
 
   const coversOpenCount = covers.filter(c => c.state === 'open' || (c.position && c.position < 100)).length;
   const anyCoversOpen = coversOpenCount > 0;
+
+  const anyLocksUnlocked = locks.some(l => l.state === 'unlocked');
+  const anyTVsOn = tvs.some(tv => tv.state === 'on');
+  const anyGaragesOpen = garages.some(g => g.state === 'open');
+  const anyMediaPlaying = mediaPlayers.some(mp => mp.state === 'playing');
 
   // Handler for executing scene button action
   const executeSceneButton = (button) => {
@@ -219,6 +228,42 @@ function renderQuickActions(component, html, areaId) {
         >
           <ha-icon icon="${anyCoversOpen ? 'mdi:window-shutter' : 'mdi:window-shutter-open'}"></ha-icon>
           <span>${anyCoversOpen ? t('popup.actions.covers_close') : t('popup.actions.covers_open')}</span>
+        </button>
+      ` : ''}
+      ${anyLocksUnlocked ? html`
+        <button
+          class="popup-scene-button"
+          @click=${() => { triggerHaptic('light'); component._lockAllRoom(areaId); }}
+        >
+          <ha-icon icon="mdi:lock-open"></ha-icon>
+          <span>${t('popup.actions.lock_all')}</span>
+        </button>
+      ` : ''}
+      ${anyTVsOn ? html`
+        <button
+          class="popup-scene-button"
+          @click=${() => { triggerHaptic('light'); component._turnOffAllRoomTVs(areaId); }}
+        >
+          <ha-icon icon="mdi:television-off"></ha-icon>
+          <span>${t('popup.actions.tvs_off')}</span>
+        </button>
+      ` : ''}
+      ${anyGaragesOpen ? html`
+        <button
+          class="popup-scene-button"
+          @click=${() => { triggerHaptic('light'); component._closeAllRoomGarages(areaId); }}
+        >
+          <ha-icon icon="mdi:garage-open"></ha-icon>
+          <span>${t('popup.actions.close_garages')}</span>
+        </button>
+      ` : ''}
+      ${anyMediaPlaying ? html`
+        <button
+          class="popup-scene-button"
+          @click=${() => { triggerHaptic('light'); component._stopAllRoomMedia(areaId); }}
+        >
+          <ha-icon icon="mdi:stop"></ha-icon>
+          <span>${t('popup.actions.stop_media')}</span>
         </button>
       ` : ''}
       ${roomSceneButtons.map(button => html`

--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -406,7 +406,11 @@
       "all_covers": "Alle Rollos",
       "close_all": "Alle schließen",
       "open_all": "Alle öffnen",
-      "turn_off_all": "Alle ausschalten"
+      "turn_off_all": "Alle ausschalten",
+      "lock_all": "Alle verriegeln",
+      "tvs_off": "Fernseher aus",
+      "close_garages": "Alle schließen",
+      "stop_media": "Alle stoppen"
     }
   },
   "admin": {

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -406,7 +406,11 @@
       "all_covers": "All covers",
       "close_all": "Close all",
       "open_all": "Open all",
-      "turn_off_all": "Turn off all"
+      "turn_off_all": "Turn off all",
+      "lock_all": "Lock all",
+      "tvs_off": "TVs off",
+      "close_garages": "Close all",
+      "stop_media": "Stop all"
     }
   },
   "admin": {


### PR DESCRIPTION
## Summary

Adds four new quick action buttons to the room popup, closing #107.

All follow the **"fix it" pattern** — only shown when there's something to fix, no inverse action.

### New quick actions

| Button | Condition | Icon | Action |
|--------|-----------|------|--------|
| 🔒 **Lock all** | Any lock unlocked | `mdi:lock-open` | `lock.lock` on all room locks |
| 📺 **TVs off** | Any TV on | `mdi:television-off` | `media_player.turn_off` on all room TVs |
| 🚗 **Close all** | Any garage open | `mdi:garage-open` | `cover.close_cover` on all room garages |
| 🎵 **Stop all** | Any media playing | `mdi:stop` | `media_player.media_stop` on all room media players |

### Changes

- **dashview-panel.js**: Added `_lockAllRoom`, `_turnOffAllRoomTVs`, `_closeAllRoomGarages`, `_stopAllRoomMedia` methods
- **room-popup.js**: Extended `renderQuickActions()` with 4 conditional buttons after covers, before scenes
- **en.json / de.json**: Added locale keys (`lock_all`, `tvs_off`, `close_garages`, `stop_media`)

### Testing

All tests pass (14 pre-existing failures unchanged).

Closes #107