### PR TITLE
feat: add smoke detector alerts to main dashboard info text (#111)

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -4240,6 +4240,7 @@ if (typeof structuredClone === 'undefined') {
               enabledTVs: this._buildEnabledMapFromRegistry(this._tvLabelId, this._enabledTVs),
               enabledLocks: this._buildEnabledMapFromRegistry(this._lockLabelId, this._enabledLocks),
               enabledWaterLeakSensors: this._buildEnabledMapFromRegistry(this._waterLeakLabelId, this._enabledWaterLeakSensors),
+              enabledSmokeSensors: this._buildEnabledMapFromRegistry(this._smokeLabelId, this._enabledSmokeSensors),
             },
             {
               motionLabelId: this._motionLabelId,
@@ -4250,6 +4251,7 @@ if (typeof structuredClone === 'undefined') {
               tvLabelId: this._tvLabelId,
               lockLabelId: this._lockLabelId,
               waterLeakLabelId: this._waterLeakLabelId,
+              smokeLabelId: this._smokeLabelId,
             },
             (entityId, labelId) => this._entityHasCurrentLabel(entityId, labelId),
             appliancesWithHomeStatus,

--- a/custom_components/dashview/frontend/features/admin/layout-tab.js
+++ b/custom_components/dashview/frontend/features/admin/layout-tab.js
@@ -881,6 +881,10 @@ export function renderCardConfig(panel, html) {
         ${renderInfoTextToggle(panel, html, 'tvs', t('admin.infoTextToggles.tvs'), 'mdi:television',
           t('admin.infoTextToggles.tvsDesc'))}
 
+        <!-- Smoke Detector Status -->
+        ${renderInfoTextToggle(panel, html, 'smoke', t('admin.infoTextToggles.smoke'), 'mdi:smoke-detector',
+          t('admin.infoTextToggles.smokeDesc'))}
+
         <!-- Washer Status -->
         ${renderInfoTextEntityConfig(panel, html, 'washer', t('admin.infoTextToggles.washer'), 'mdi:washing-machine',
           t('admin.infoTextToggles.washerDesc'), true)}

--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -268,6 +268,10 @@
       "leakDetected": "LECK ERKANNT",
       "leaksDetected": "Lecks erkannt"
     },
+    "smoke": {
+      "detected": "RAUCH ERKANNT",
+      "detectedMultiple": "Melder ausgelöst"
+    },
     "door": {
       "open_suffix": "Türen offen.",
       "open_too_long_single": "{{name}} offen {{duration}}",
@@ -641,6 +645,8 @@
       "tvsDesc": "Zeigt eingeschaltete Fernseher an",
       "water": "Wasserleck",
       "waterDesc": "Zeigt Status der Wasserleck-Sensoren an",
+      "smoke": "Rauchmelder",
+      "smokeDesc": "Zeigt Rauchmelder-Alarme auf dem Dashboard an",
       "washer": "Waschmaschine",
       "washerDesc": "Zeigt Status der Waschmaschine an",
       "dishwasher": "Geschirrspüler",

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -268,6 +268,10 @@
       "leakDetected": "LEAK DETECTED",
       "leaksDetected": "leaks detected"
     },
+    "smoke": {
+      "detected": "SMOKE DETECTED",
+      "detectedMultiple": "detectors triggered"
+    },
     "door": {
       "open_suffix": "doors open.",
       "open_too_long_single": "{{name}} open {{duration}}",
@@ -641,6 +645,8 @@
       "tvsDesc": "Shows TVs turned on",
       "water": "Water Leak",
       "waterDesc": "Shows water leak sensor status",
+      "smoke": "Smoke Detectors",
+      "smokeDesc": "Shows smoke detector alerts on the dashboard",
       "washer": "Washing Machine",
       "washerDesc": "Shows washing machine status",
       "dishwasher": "Dishwasher",

--- a/custom_components/dashview/frontend/services/index.js
+++ b/custom_components/dashview/frontend/services/index.js
@@ -41,6 +41,7 @@ export {
 // Status Service
 export {
   getWasherStatus,
+  getSmokeStatus,
   getMotionStatus,
   getGarageStatus,
   getWindowsStatus,

--- a/custom_components/dashview/frontend/services/status-service.js
+++ b/custom_components/dashview/frontend/services/status-service.js
@@ -145,6 +145,86 @@ export function getWaterLeakStatus(hass, infoTextConfig, enabledWaterLeakSensors
 }
 
 /**
+ * Get smoke detector status for info text row
+ * Only shows when smoke is actively detected (life safety critical)
+ * @param {Object} hass - Home Assistant instance
+ * @param {Object} infoTextConfig - Info text configuration
+ * @param {Object} enabledSmokeSensors - Map of enabled smoke sensor IDs
+ * @param {string|null} labelId - Optional label ID to filter by
+ * @param {Function|null} entityHasLabel - Optional function to check if entity has label
+ * @returns {Object|null} Status object or null
+ */
+export function getSmokeStatus(hass, infoTextConfig, enabledSmokeSensors, labelId = null, entityHasLabel = null) {
+  if (!hass || !infoTextConfig.smoke?.enabled) return null;
+
+  // Get enabled smoke sensor IDs
+  let enabledSmokeSensorIds = getEnabledEntityIds(enabledSmokeSensors);
+
+  // Filter by label if provided
+  if (labelId && entityHasLabel) {
+    enabledSmokeSensorIds = enabledSmokeSensorIds.filter(id => entityHasLabel(id, labelId));
+  }
+
+  if (enabledSmokeSensorIds.length === 0) return null;
+
+  // Find all sensors that are currently detecting smoke (state 'on')
+  const activeSensors = enabledSmokeSensorIds
+    .map(entityId => {
+      const state = hass.states[entityId];
+      if (state && state.state === 'on') {
+        return {
+          entityId,
+          name: state.attributes?.friendly_name || entityId,
+          lastChanged: state.last_changed ? new Date(state.last_changed) : null,
+        };
+      }
+      return null;
+    })
+    .filter(s => s !== null);
+
+  // Only show when smoke is actively detected — no "all clear" status
+  if (activeSensors.length === 0) return null;
+
+  const count = activeSensors.length;
+
+  if (count === 1) {
+    // Single detector — show name
+    const sensor = activeSensors[0];
+    return {
+      state: 'alert',
+      prefixText: t('status.smoke.detected'),
+      badgeText: sensor.name,
+      badgeIcon: 'mdi:smoke-detector-variant-alert',
+      suffixText: '!',
+      isWarning: true,
+      isCritical: true,
+      clickAction: 'smoke',
+      priority: 100,
+      alertId: `smoke:${sensor.entityId}`,
+      entityLastChanged: sensor.lastChanged ? sensor.lastChanged.toISOString() : null,
+    };
+  } else {
+    // Multiple detectors — show count
+    const earliestSensor = activeSensors.reduce((earliest, current) =>
+      current.lastChanged && (!earliest.lastChanged || current.lastChanged < earliest.lastChanged) ? current : earliest
+    );
+    return {
+      state: 'alert',
+      prefixText: t('status.smoke.detected'),
+      badgeText: `${count}`,
+      badgeIcon: 'mdi:smoke-detector-variant-alert',
+      suffixText: t('status.smoke.detectedMultiple') + '!',
+      isWarning: true,
+      isCritical: true,
+      clickAction: 'smoke',
+      priority: 100,
+      alertId: 'smoke:multiple',
+      entityLastChanged: earliestSensor.lastChanged ? earliestSensor.lastChanged.toISOString() : null,
+    };
+  }
+}
+
+/**
  * Get motion status for info text row
  * @param {Object} hass - Home Assistant instance
  * @param {Object} infoTextConfig - Info text configuration
@@ -995,6 +1075,7 @@ export function getAllStatusItems(hass, infoTextConfig, enabledEntities, labelId
     enabledCovers = {},
     enabledTVs = {},
     enabledWaterLeakSensors = {},
+    enabledSmokeSensors = {},
   } = enabledEntities;
 
   const {
@@ -1006,6 +1087,7 @@ export function getAllStatusItems(hass, infoTextConfig, enabledEntities, labelId
     coverLabelId = null,
     tvLabelId = null,
     waterLeakLabelId = null,
+    smokeLabelId = null,
   } = labelIds;
 
   const {
@@ -1018,8 +1100,9 @@ export function getAllStatusItems(hass, infoTextConfig, enabledEntities, labelId
   const applianceStatusItems = getAppliancesStatus(hass, infoTextConfig, appliancesWithHomeStatus, getApplianceStatus);
 
   return [
-    // Water leak is highest priority (property damage)
+    // Water leak and smoke are highest priority (life safety)
     getWaterLeakStatus(hass, infoTextConfig, enabledWaterLeakSensors, waterLeakLabelId, entityHasLabel),
+    getSmokeStatus(hass, infoTextConfig, enabledSmokeSensors, smokeLabelId, entityHasLabel),
     // Door/garage/window open-too-long alerts (security concerns)
     getDoorStatus(hass, infoTextConfig, enabledDoors, doorOpenTooLongMinutes, doorLabelId, entityHasLabel),
     getGarageStatus(hass, infoTextConfig, enabledGarages, garageOpenTooLongMinutes, garageLabelId, entityHasLabel),
@@ -1036,6 +1119,7 @@ export function getAllStatusItems(hass, infoTextConfig, enabledEntities, labelId
 export default {
   getWasherStatus,
   getWaterLeakStatus,
+  getSmokeStatus,
   getMotionStatus,
   getGarageStatus,
   getDoorStatus,

--- a/custom_components/dashview/frontend/stores/settings-store.js
+++ b/custom_components/dashview/frontend/stores/settings-store.js
@@ -189,6 +189,7 @@ export const DEFAULT_SETTINGS = {
     lights: { enabled: false },
     covers: { enabled: false },
     water: { enabled: false },
+    smoke: { enabled: false },
     dishwasher: { enabled: false, entity: '', finishTimeEntity: '' },
     dryer: { enabled: false, entity: '', finishTimeEntity: '' },
     vacuum: { enabled: false, entity: '' },


### PR DESCRIPTION
## Summary

Adds smoke detector status to the main dashboard info text area, following the existing water leak pattern. This is a **partial** implementation of #111 — vibration sensors were intentionally excluded per maintainer decision.

## Changes

### 1. `status-service.js` — New `getSmokeStatus()` function
- Checks `infoTextConfig.smoke?.enabled`
- Gets enabled smoke sensor IDs, filters by label
- Finds sensors with state `on` (smoke detected)
- Single detector: shows name (e.g. "SMOKE DETECTED Kitchen smoke detector!")
- Multiple detectors: shows count (e.g. "SMOKE DETECTED 2 detectors triggered!")
- Uses `isCritical: true` (life safety — highest priority alongside water)
- `priority: 100`, same as water leak
- `alertId: 'smoke:entityId'` for dismissibility
- Returns `null` when no smoke detected (no "all clear" status — unlike water leak)
- Wired into `getAllStatusItems()` right after water leak

### 2. `dashview-panel.js` — Wiring
- Added `enabledSmokeSensors` and `smokeLabelId` to the `enabledEntities` and `labelIds` objects passed to `getAllStatusItems()`
- Properties already existed from room popup chip support

### 3. `layout-tab.js` — Admin toggle
- Added smoke detector toggle in the Info Text Configuration section
- Uses `mdi:smoke-detector` icon

### 4. `settings-store.js` — Default config
- Added `smoke: { enabled: false }` to `infoTextConfig` defaults

### 5. Locale files (en.json + de.json)
- `status.smoke.detected` / "SMOKE DETECTED" / "RAUCH ERKANNT"
- `status.smoke.detectedMultiple` / "detectors triggered" / "Melder ausgelöst"
- `admin.infoTextToggles.smoke` / "Smoke Detectors" / "Rauchmelder"
- `admin.infoTextToggles.smokeDesc` / descriptions in both languages

### 6. `services/index.js` — Export
- Exported `getSmokeStatus` from the services barrel file

## Design Decisions
- **`isCritical: true`** — Smoke is life safety, not just a warning
- **No "all clear" status** — Only shows when smoke is actively detected
- **Vibration excluded** — Per maintainer decision, not part of this PR

## Testing
- `npx vitest run` — 14 pre-existing failures, **0 new failures**
- All status-service tests pass

Closes partially #111