### PR TITLE
feat(weather): UV index display in weather popup

### DIFF
--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -244,6 +244,14 @@
       "severe_warning": "Unwetterwarnung vor",
       "extreme_warning": "Extremes Unwetter"
     },
+    "uv_index": "UV-Index",
+    "uv_peak": "UV-Maximum",
+    "uv_protection": "Sonnenschutz empfohlen",
+    "uv_low": "Niedrig",
+    "uv_moderate": "Mäßig",
+    "uv_high": "Hoch",
+    "uv_very_high": "Sehr hoch",
+    "uv_extreme": "Extrem",
     "pollen": "Pollenflug",
     "pollen_types": {
       "erle": "Erle",

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -244,6 +244,14 @@
       "severe_warning": "Severe weather warning",
       "extreme_warning": "Extreme weather"
     },
+    "uv_index": "UV Index",
+    "uv_peak": "Peak UV",
+    "uv_protection": "Protection recommended",
+    "uv_low": "Low",
+    "uv_moderate": "Moderate",
+    "uv_high": "High",
+    "uv_very_high": "Very High",
+    "uv_extreme": "Extreme",
     "pollen": "Pollen Forecast",
     "pollen_types": {
       "erle": "Alder",

--- a/custom_components/dashview/frontend/services/weather-service.js
+++ b/custom_components/dashview/frontend/services/weather-service.js
@@ -201,6 +201,7 @@ export function getForecastData(hass, type, forecasts, weatherEntity) {
         precipitation_probability: forecast.precipitation_probability,
         wind_speed: forecast.wind_speed,
         datetime: forecast.datetime,
+        uv_index: forecast.uv_index,
       };
     }
   }
@@ -220,6 +221,7 @@ export function getForecastData(hass, type, forecasts, weatherEntity) {
         precipitation_probability: forecast.precipitation_probability,
         wind_speed: forecast.wind_speed,
         datetime: forecast.datetime,
+        uv_index: forecast.uv_index,
       };
     }
   }

--- a/custom_components/dashview/frontend/styles/popups/weather.js
+++ b/custom_components/dashview/frontend/styles/popups/weather.js
@@ -393,4 +393,90 @@ export const weatherPopupStyles = `
   .pollen-item-trend ha-icon {
     --mdc-icon-size: 14px;
   }
+
+  /* ==================== UV INDEX ==================== */
+
+  /* Current card with UV row: add grid area */
+  .weather-current-card.has-uv {
+    grid-template-areas:
+      "title icon"
+      "temp icon"
+      "condition icon"
+      "uvrow uvrow";
+    grid-template-rows: auto auto auto auto;
+  }
+
+  .weather-current-uv {
+    grid-area: uvrow;
+  }
+
+  /* Forecast card with UV row: add grid area */
+  .weather-forecast-card.has-uv {
+    grid-template-areas:
+      "title icon"
+      "temp icon"
+      "condition icon"
+      "uvrow uvrow";
+    grid-template-rows: auto auto auto auto;
+  }
+
+  .weather-forecast-uv {
+    grid-area: uvrow;
+  }
+
+  /* UV footer row — shared between current and forecast cards */
+  .forecast-uv-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-top: 1px solid var(--dv-gray300, rgba(0,0,0,0.1));
+    padding-top: 10px;
+    margin-top: 8px;
+    margin-left: 15px;
+    margin-right: 15px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+  }
+
+  .forecast-uv-icon {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  .forecast-uv-text {
+    font-size: 12px;
+    color: var(--dv-gray800, var(--secondary-text-color));
+  }
+
+  .forecast-uv-value {
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  .forecast-uv-level {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 10px;
+    line-height: 1.4;
+  }
+
+  .forecast-uv-protection {
+    font-size: 11px;
+    color: var(--dv-gray800, var(--secondary-text-color));
+    font-style: italic;
+    width: 100%;
+    margin-top: -2px;
+    padding-left: 24px;
+  }
+
+  /* UV badge in hourly forecast items */
+  .weather-hourly-uv {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 8px;
+    margin-top: 4px;
+    white-space: nowrap;
+  }
 `;


### PR DESCRIPTION
Adds UV index from weather entity attributes to the weather popup.

## Changes
- **Current weather card:** UV footer row with color-coded value + level badge + protection advice (moderate+)
- **Hourly forecast:** Color-coded UV badges per hour (when `uv_index` present in forecast data)
- **Forecast cards:** Peak UV row with same format as current card
- **Weather service:** Forward `uv_index` from forecast data
- **i18n:** EN + DE translations for all UV-related strings
- **Styles:** UV row, badge, and protection text styles

## UV Color Scale
| UV Index | Level | Color |
|----------|-------|-------|
| 0–2 | Low | 🟢 Green |
| 3–5 | Moderate | 🟠 Orange |
| 6–7 | High | 🔴 Red |
| 8–10 | Very High | 🟣 Purple |
| 11+ | Extreme | 🩷 Pink |

## Data Source
Reads `uv_index` from `weather.*` entity attributes (available in OpenWeatherMap v3.0, AccuWeather). Zero configuration needed — UV row only renders when the attribute exists.

## Files Changed
- `features/popups/weather-popup.js` — UV helpers + render logic for all 3 card types
- `services/weather-service.js` — Pass through `uv_index` in forecast data
- `styles/popups/weather.js` — UV row, badge, and protection styles
- `locales/en.json` — English translations
- `locales/de.json` — German translations

Closes #42