### PR TITLE
feat(security): Security summary card on main dashboard

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -1382,9 +1382,15 @@ if (typeof structuredClone === 'undefined') {
       const currentFloorConfig = this._floorCardConfig[floorId] || {};
 
       // For appliances, store additional data needed for device card rendering
+      // For security summary, store type: 'security'
       let slotData = null;
       if (entityId) {
-        if (entityData && entityData.type === 'appliance' && entityData.appliance) {
+        if (entityData && entityData.type === 'security') {
+          slotData = {
+            entity_id: entityId,
+            type: 'security',
+          };
+        } else if (entityData && entityData.type === 'appliance' && entityData.appliance) {
           slotData = {
             entity_id: entityId,
             type: 'appliance',

--- a/custom_components/dashview/frontend/features/admin/layout-tab.js
+++ b/custom_components/dashview/frontend/features/admin/layout-tab.js
@@ -2217,10 +2217,13 @@ export function renderLayoutTab(panel, html) {
     const isConfigured = !!entityId;
     // For appliances, get display info from stored appliance object
     const isAppliance = slotConfig?.type === 'appliance' && slotConfig?.appliance;
+    const isSecurity = slotConfig?.type === 'security';
     const entityInfo = isConfigured
-      ? (isAppliance
-        ? { name: slotConfig.appliance.name, icon: slotConfig.appliance.icon || 'mdi:devices' }
-        : getEntityDisplayInfo(entityId))
+      ? (isSecurity
+        ? { name: t('security.summary.cardName'), icon: 'mdi:shield-check' }
+        : isAppliance
+          ? { name: slotConfig.appliance.name, icon: slotConfig.appliance.icon || 'mdi:devices' }
+          : getEntityDisplayInfo(entityId))
       : null;
     const isSelected = panel._selectedFloorCardSlot === `${floorId}-${slotIndex}`;
 
@@ -2325,6 +2328,15 @@ export function renderLayoutTab(panel, html) {
       });
     });
 
+    // Add Security Summary card as a special virtual entity (always available, floor-independent)
+    entities.unshift({
+      entity_id: 'virtual:security-summary',
+      name: t('security.summary.cardName'),
+      type: 'security',
+      area: '🛡️',
+      icon: 'mdi:shield-check',
+    });
+
     return entities;
   };
 
@@ -2338,12 +2350,15 @@ export function renderLayoutTab(panel, html) {
     const slotConfig = config[slotIndex] || null;
     const entityId = slotConfig?.entity_id;
     const isConfigured = !!entityId;
-    // For appliances, get display info from stored appliance object; otherwise use hass state
+    // For appliances, get display info from stored appliance object; for security, use card name; otherwise use hass state
     const isAppliance = slotConfig?.type === 'appliance' && slotConfig?.appliance;
+    const isSecurity = slotConfig?.type === 'security';
     const entityInfo = isConfigured
-      ? (isAppliance
-        ? { name: slotConfig.appliance.name, icon: slotConfig.appliance.icon || 'mdi:devices' }
-        : getEntityDisplayInfo(entityId))
+      ? (isSecurity
+        ? { name: t('security.summary.cardName'), icon: 'mdi:shield-check' }
+        : isAppliance
+          ? { name: slotConfig.appliance.name, icon: slotConfig.appliance.icon || 'mdi:devices' }
+          : getEntityDisplayInfo(entityId))
       : null;
     const entities = getFloorEntities(floorId);
 
@@ -2424,8 +2439,8 @@ export function renderLayoutTab(panel, html) {
                       class="entity-picker-suggestion"
                       @mousedown=${(e) => {
                         e.preventDefault();
-                        // For appliances, pass the full entity object; for others just the entity_id
-                        if (entity.type === 'appliance') {
+                        // For appliances and security, pass the full entity object; for others just the entity_id
+                        if (entity.type === 'appliance' || entity.type === 'security') {
                           panel._handleFloorCardEntityChange(floorId, slotIndex, entity.entity_id, entity);
                         } else {
                           panel._handleFloorCardEntityChange(floorId, slotIndex, entity.entity_id);
@@ -2437,7 +2452,7 @@ export function renderLayoutTab(panel, html) {
                       <ha-icon icon="${entity.icon}"></ha-icon>
                       <div class="entity-picker-suggestion-info">
                         <div class="entity-picker-suggestion-name">${entity.area}: ${entity.name}</div>
-                        ${entity.type !== 'appliance' ? html`
+                        ${entity.type !== 'appliance' && entity.type !== 'security' ? html`
                           <div class="entity-picker-suggestion-entity">${entity.entity_id}</div>
                         ` : ''}
                       </div>
@@ -2451,13 +2466,13 @@ export function renderLayoutTab(panel, html) {
 
         ${isConfigured && entityInfo ? html`
           <div class="garbage-selected-sensors" style="margin-top: 8px;">
-            <label style="display: block; font-weight: 500; margin-bottom: 8px; color: var(--dv-gray800);">${isAppliance ? t('admin.layout.selectedDevice') : t('admin.layout.selectedEntity')}</label>
+            <label style="display: block; font-weight: 500; margin-bottom: 8px; color: var(--dv-gray800);">${isAppliance ? t('admin.layout.selectedDevice') : isSecurity ? t('security.summary.cardName') : t('admin.layout.selectedEntity')}</label>
             <div class="garbage-sensor-list">
               <div class="garbage-sensor-item selected">
                 <ha-icon icon="${entityInfo.icon}"></ha-icon>
                 <div class="garbage-sensor-info">
                   <div class="garbage-sensor-name">${entityInfo.name}</div>
-                  ${!isAppliance ? html`
+                  ${!isAppliance && !isSecurity ? html`
                     <div class="garbage-sensor-entity">${entityId}</div>
                   ` : ''}
                 </div>

--- a/custom_components/dashview/frontend/features/admin/onboarding/steps/floor-cards-step.js
+++ b/custom_components/dashview/frontend/features/admin/onboarding/steps/floor-cards-step.js
@@ -427,7 +427,16 @@ export function renderFloorCardsStep(panel, html) {
       }
     });
 
-    return entities.sort((a, b) => a.name.localeCompare(b.name));
+    // Add Security Summary card as a special option
+    entities.unshift({
+      entity_id: 'virtual:security-summary',
+      name: t('security.summary.cardName', 'Security Summary'),
+      type: 'security',
+      area: '🛡️',
+      icon: 'mdi:shield-check',
+    });
+
+    return entities;
   };
 
   // Toggle floor overview
@@ -452,11 +461,18 @@ export function renderFloorCardsStep(panel, html) {
       state.floorCardConfig[floorId] = {};
     }
     if (entityId) {
-      const entity = entities.find(e => e.entity_id === entityId);
-      state.floorCardConfig[floorId][slotIndex] = {
-        entity_id: entityId,
-        type: 'entity'
-      };
+      // Check if this is a security summary virtual entity
+      if (entityId === 'virtual:security-summary') {
+        state.floorCardConfig[floorId][slotIndex] = {
+          entity_id: entityId,
+          type: 'security'
+        };
+      } else {
+        state.floorCardConfig[floorId][slotIndex] = {
+          entity_id: entityId,
+          type: 'entity'
+        };
+      }
     } else {
       delete state.floorCardConfig[floorId][slotIndex];
     }

--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -1209,6 +1209,23 @@
       "empty": "Keine Türsensoren in der Admin-Konfiguration aktiviert.",
       "open": "Offene Türen",
       "closed": "Geschlossene Türen"
+    },
+    "summary": {
+      "allSecure": "Alles sicher",
+      "everythingLocked": "Alles verriegelt & geschlossen",
+      "issues": "{{count}} Probleme",
+      "issue": "1 Problem",
+      "windows": "{{count}} Fenster",
+      "window": "1 Fenster",
+      "doors": "{{count}} Türen",
+      "door": "1 Tür",
+      "locks": "{{count}} Schlösser",
+      "lock": "1 Schloss",
+      "garages": "{{count}} Garagen",
+      "garage": "1 Garage",
+      "smokeAlert": "Rauchalarm",
+      "waterAlert": "Wasseralarm",
+      "cardName": "Sicherheit"
     }
   }
 }

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -1085,6 +1085,23 @@
       "empty": "No door sensors enabled in admin configuration.",
       "open": "Open Doors",
       "closed": "Closed Doors"
+    },
+    "summary": {
+      "allSecure": "All Secure",
+      "everythingLocked": "Everything locked & closed",
+      "issues": "{{count}} Issues",
+      "issue": "1 Issue",
+      "windows": "{{count}} Windows",
+      "window": "1 Window",
+      "doors": "{{count}} Doors",
+      "door": "1 Door",
+      "locks": "{{count}} Locks",
+      "lock": "1 Lock",
+      "garages": "{{count}} Garages",
+      "garage": "1 Garage",
+      "smokeAlert": "Smoke Alert",
+      "waterAlert": "Water Alert",
+      "cardName": "Security Summary"
     }
   },
   "onboarding": {

--- a/custom_components/dashview/frontend/styles/components/cards.js
+++ b/custom_components/dashview/frontend/styles/components/cards.js
@@ -1,6 +1,6 @@
 /**
  * Card Styles
- * Floor device cards and garbage collection cards
+ * Floor device cards, garbage collection cards, and security summary card
  */
 
 export const cardStyles = `
@@ -541,6 +541,175 @@ export const cardStyles = `
   .garbage-sensor-remove:hover {
     color: var(--dv-red);
     background: rgba(240, 169, 148, 0.2);
+  }
+
+  /* ==================== SECURITY SUMMARY CARD ==================== */
+  .security-summary-card {
+    position: relative;
+    border-radius: var(--dv-radius-md);
+    cursor: pointer;
+    transition: all var(--dv-transition-normal) ease;
+    overflow: hidden;
+    box-sizing: border-box;
+    margin: 4px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .security-summary-card:hover {
+    transform: scale(0.98);
+  }
+
+  .security-summary-card:active {
+    transform: scale(0.96);
+  }
+
+  /* State: All Secure (green) */
+  .security-summary-card.secure {
+    background: var(--dv-green);
+  }
+
+  /* State: Issues detected (amber/warning) */
+  .security-summary-card.warning {
+    background: var(--dv-yellow);
+  }
+
+  /* State: Critical (smoke/water - red) */
+  .security-summary-card.critical {
+    background: var(--dv-red);
+  }
+
+  @keyframes security-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+  }
+
+  .security-summary-card.critical {
+    animation: security-pulse 2s ease-in-out infinite;
+  }
+
+  /* Small card layout (horizontal) */
+  .security-summary-card.small {
+    height: calc(100% - 8px);
+    padding: 4px 20px 4px 4px;
+  }
+
+  /* Big card layout (vertical) — matches garbage/floor-device card grid */
+  .security-summary-card.big {
+    height: calc(100% - 8px);
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
+    padding: 20px;
+    gap: 4px;
+  }
+
+  /* Icon container */
+  .security-summary-card-icon {
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .security-summary-card.small .security-summary-card-icon {
+    width: 50px;
+    height: 50px;
+  }
+
+  .security-summary-card.big .security-summary-card-icon {
+    width: 50px;
+    height: 50px;
+    align-self: flex-end;
+    margin: -6px -6px 0 0;
+    position: absolute;
+    top: 20px;
+    right: 20px;
+  }
+
+  .security-summary-card.secure .security-summary-card-icon {
+    background: var(--dv-gray000);
+  }
+
+  .security-summary-card.warning .security-summary-card-icon {
+    background: var(--dv-gray000);
+  }
+
+  .security-summary-card.critical .security-summary-card-icon {
+    background: var(--dv-gray800);
+  }
+
+  .security-summary-card-icon ha-icon {
+    --mdc-icon-size: 22px;
+    color: var(--dv-gray800);
+  }
+
+  .security-summary-card.big .security-summary-card-icon ha-icon {
+    --mdc-icon-size: 30px;
+  }
+
+  .security-summary-card.critical .security-summary-card-icon ha-icon {
+    color: var(--dv-gray000);
+  }
+
+  /* Content area */
+  .security-summary-card-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* Title text */
+  .security-summary-card-title {
+    font-weight: 500;
+    color: var(--dv-gray800);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .security-summary-card.small .security-summary-card-title {
+    font-size: 16px;
+  }
+
+  .security-summary-card.big .security-summary-card-title {
+    font-size: 1.5em;
+    font-weight: 300;
+  }
+
+  .security-summary-card.critical .security-summary-card-title {
+    color: var(--dv-white);
+    font-weight: 600;
+  }
+
+  /* Use fixed dark for green/yellow backgrounds */
+  .security-summary-card.secure .security-summary-card-title,
+  .security-summary-card.warning .security-summary-card-title {
+    color: var(--dv-fixed-dark, var(--dv-gray800));
+  }
+
+  /* Detail text below title */
+  .security-summary-card-detail {
+    font-size: 14px;
+    opacity: 0.7;
+    color: var(--dv-gray800);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .security-summary-card.critical .security-summary-card-detail {
+    color: var(--dv-white);
+  }
+
+  .security-summary-card.secure .security-summary-card-detail,
+  .security-summary-card.warning .security-summary-card-detail {
+    color: var(--dv-fixed-dark, var(--dv-gray800));
   }
 
 `;


### PR DESCRIPTION
Adds an at-a-glance security summary card that can be placed in any floor card slot.

## Changes
- New security summary card type for floor card grid
- Three states: All Secure (green), Issues (amber), Critical (red)
- Shows counts: open windows, doors, garages, unlocked locks, smoke/water alerts
- Tapping opens the security popup for detailed view
- Admin: can assign "Security Summary" to any floor card slot
- Wizard: security card available in floor cards setup step
- i18n: EN + DE translations

## States
- 🟢 All Secure — shield-check icon, green tint, "Everything locked & closed"
- 🟡 Issues — shield-alert icon, amber tint, "2 Windows · 1 Lock"
- 🔴 Critical — smoke/water alert, red tint with pulse animation, "SMOKE ALERT"

## Files Changed
- `features/home/index.js` — `renderSecuritySummaryCard()` + `getSecurityCounts()` + registration in `renderCard()`
- `features/admin/layout-tab.js` — Security card as selectable option in floor card entity picker
- `features/admin/onboarding/steps/floor-cards-step.js` — Security card in wizard entity picker
- `dashview-panel.js` — Handle `type: "security"` in `_handleFloorCardEntityChange()`
- `styles/components/cards.js` — Security summary card CSS (secure/warning/critical states + pulse animation)
- `locales/en.json` + `locales/de.json` — 15 new i18n keys under `security.summary.*`

Relates to #40