### PR TITLE
fix: replace hardcoded German strings in getAlarmStatus() with i18n (#157)

### DIFF
--- a/custom_components/dashview/frontend/services/status-service.js
+++ b/custom_components/dashview/frontend/services/status-service.js
@@ -1335,32 +1335,32 @@ export function getAlarmStatus(hass, infoTextConfig, alarmEntity) {
   // Map states to display information
   const stateMapping = {
     disarmed: {
-      prefixText: 'Alarm ist',
-      badgeText: 'unscharf',
+      prefixText: t('status.alarm.disarmed'),
+      badgeText: t('status.alarm.disarmed'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_home: {
-      prefixText: 'Alarm ist',
-      badgeText: 'scharf (Zuhause)',
+      prefixText: t('status.alarm.armed_home'),
+      badgeText: t('status.alarm.armed_home'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_away: {
-      prefixText: 'Alarm ist',
-      badgeText: 'scharf (Abwesend)',
+      prefixText: t('status.alarm.armed_away'),
+      badgeText: t('status.alarm.armed_away'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_night: {
-      prefixText: 'Alarm ist',
-      badgeText: 'scharf (Nacht)',
+      prefixText: t('status.alarm.armed_night'),
+      badgeText: t('status.alarm.armed_night'),
       emoji: '🛡️',
       isWarning: false
     },
     triggered: {
       prefixText: '⚠️',
-      badgeText: 'ALARM AUSGELÖST',
+      badgeText: t('status.alarm.triggered'),
       emoji: '🚨',
       suffixText: '!',
       isWarning: true,


### PR DESCRIPTION
## Summary

Fixes #157 — `getAlarmStatus()` in `status-service.js` used hardcoded German strings (`'Alarm ist'`, `'unscharf'`, `'scharf (Zuhause)'`, etc.) instead of the existing i18n translation keys.

## Changes

Replaced all hardcoded German strings in the `stateMapping` object inside `getAlarmStatus()` with `t()` calls using the existing i18n keys:

| State | Before (hardcoded) | After (i18n) |
|---|---|---|
| `disarmed` | `'Alarm ist'` / `'unscharf'` | `t('status.alarm.disarmed')` |
| `armed_home` | `'Alarm ist'` / `'scharf (Zuhause)'` | `t('status.alarm.armed_home')` |
| `armed_away` | `'Alarm ist'` / `'scharf (Abwesend)'` | `t('status.alarm.armed_away')` |
| `armed_night` | `'Alarm ist'` / `'scharf (Nacht)'` | `t('status.alarm.armed_night')` |
| `triggered` | `'ALARM AUSGELÖST'` | `t('status.alarm.triggered')` |

The `t` function was already imported at the top of the file from `../utils/i18n.js`.

## Testing

All 1138 tests pass (`npx vitest run`).