### PR TITLE
fix: replace hardcoded English in anomaly-detector formatDuration() with i18n (#158)

### DIFF
--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -463,7 +463,11 @@
     "minutes_ago": "vor {{count}}m",
     "just_now": "Gerade eben",
     "today": "Heute",
-    "yesterday": "Gestern"
+    "yesterday": "Gestern",
+    "duration_1_hour": "1 Stunde",
+    "duration_n_hours": "{{count}} Stunden",
+    "duration_1_minute": "1 Minute",
+    "duration_n_minutes": "{{count}} Minuten"
   },
   "lock": {
     "locked": "Verschlossen",

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -463,7 +463,11 @@
     "minutes_ago": "{{count}}m ago",
     "just_now": "Just now",
     "today": "Today",
-    "yesterday": "Yesterday"
+    "yesterday": "Yesterday",
+    "duration_1_hour": "1 hour",
+    "duration_n_hours": "{{count}} hours",
+    "duration_1_minute": "1 minute",
+    "duration_n_minutes": "{{count}} minutes"
   },
   "lock": {
     "locked": "Locked",

--- a/custom_components/dashview/frontend/services/anomaly-detector.js
+++ b/custom_components/dashview/frontend/services/anomaly-detector.js
@@ -6,6 +6,8 @@
  * configured thresholds, helping identify HVAC issues or open windows.
  */
 
+import { t } from '../utils/i18n.js';
+
 /**
  * @typedef {Object} HistoryPoint
  * @property {number} time - Timestamp in milliseconds
@@ -37,16 +39,18 @@ export function formatDuration(minutes) {
   if (minutes >= 60) {
     const hours = minutes / 60;
     if (hours === 1) {
-      return '1 hour';
+      return t('time.duration_1_hour', '1 hour');
     }
     // Check if it's a whole number of hours
     if (Number.isInteger(hours)) {
-      return `${hours} hours`;
+      return t('time.duration_n_hours', { count: hours }, `${hours} hours`);
     }
-    return `${hours.toFixed(1)} hours`;
+    return t('time.duration_n_hours', { count: hours.toFixed(1) }, `${hours.toFixed(1)} hours`);
   }
   const roundedMinutes = Math.round(minutes);
-  return roundedMinutes === 1 ? '1 minute' : `${roundedMinutes} minutes`;
+  return roundedMinutes === 1
+    ? t('time.duration_1_minute', '1 minute')
+    : t('time.duration_n_minutes', { count: roundedMinutes }, `${roundedMinutes} minutes`);
 }
 
 /**

--- a/custom_components/dashview/frontend/services/anomaly-detector.test.js
+++ b/custom_components/dashview/frontend/services/anomaly-detector.test.js
@@ -3,6 +3,22 @@
  * Tests for rate-of-change detection in temperature and humidity sensors
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock i18n — return English strings matching the locale file
+vi.mock('../utils/i18n.js', () => ({
+  t: vi.fn((key, paramsOrFallback, fallback) => {
+    const translations = {
+      'time.duration_1_hour': '1 hour',
+      'time.duration_n_hours': '{{count}} hours',
+      'time.duration_1_minute': '1 minute',
+      'time.duration_n_minutes': '{{count}} minutes',
+    };
+    const template = translations[key] || fallback || key;
+    const params = typeof paramsOrFallback === 'object' ? paramsOrFallback : {};
+    return template.replace(/\{\{(\w+)\}\}/g, (_, k) => params[k] ?? '');
+  }),
+}));
+
 import {
   formatDuration,
   calculateRateOfChange,


### PR DESCRIPTION
## Summary

Fixes #158 — **anomaly-detector.js `formatDuration()` outputs hardcoded English, breaking German climate alerts**.

The local `formatDuration()` returned hardcoded English strings like `"1 hour"`, `"30 minutes"` which got injected into i18n'd climate alert templates via the `{{time}}` placeholder, producing mixed-language output for German users (e.g. *"Temperatur gefallen um 5° in 30 minutes"*).

## Changes

### `anomaly-detector.js`
- Import `t` from `../utils/i18n.js`
- Replace all hardcoded English duration strings with `t()` calls + English fallbacks

### `locales/en.json` & `locales/de.json`
Added 4 new duration keys:
| Key | English | German |
|-----|---------|--------|
| `time.duration_1_hour` | 1 hour | 1 Stunde |
| `time.duration_n_hours` | {{count}} hours | {{count}} Stunden |
| `time.duration_1_minute` | 1 minute | 1 Minute |
| `time.duration_n_minutes` | {{count}} minutes | {{count}} Minuten |

### `anomaly-detector.test.js`
- Added `vi.mock` for `../utils/i18n.js` with param substitution
- All 28 existing tests pass unchanged

## Testing
`npx vitest run` — **all 1138 tests pass** (30 test files).