### PR TITLE
fix: address code review findings from PRs #156, #159, #161

### DIFF
--- a/custom_components/dashview/frontend/locales/de.json
+++ b/custom_components/dashview/frontend/locales/de.json
@@ -420,7 +420,8 @@
       "triggered": "ALARM AUSGELÖST",
       "arming": "Wird scharf geschaltet…",
       "pending": "Ausstehend…",
-      "openSensors": "Offene Sensoren"
+      "openSensors": "Offene Sensoren",
+      "prefix": "Alarm ist"
     },
     "general": {
       "currently_are": "Aktuell sind",

--- a/custom_components/dashview/frontend/locales/en.json
+++ b/custom_components/dashview/frontend/locales/en.json
@@ -420,7 +420,8 @@
       "triggered": "ALARM TRIGGERED",
       "arming": "Arming…",
       "pending": "Pending…",
-      "openSensors": "Open Sensors"
+      "openSensors": "Open Sensors",
+      "prefix": "Alarm is"
     },
     "general": {
       "currently_are": "Currently",

--- a/custom_components/dashview/frontend/services/anomaly-detector.test.js
+++ b/custom_components/dashview/frontend/services/anomaly-detector.test.js
@@ -4,17 +4,19 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock i18n — return English strings matching the locale file
+// Mock i18n — matches real t(key, fallbackOrParams, fallbackWhenParams) signature
 vi.mock('../utils/i18n.js', () => ({
-  t: vi.fn((key, paramsOrFallback, fallback) => {
+  t: vi.fn((key, fallbackOrParams = null, fallbackWhenParams = null) => {
     const translations = {
       'time.duration_1_hour': '1 hour',
       'time.duration_n_hours': '{{count}} hours',
       'time.duration_1_minute': '1 minute',
       'time.duration_n_minutes': '{{count}} minutes',
     };
-    const template = translations[key] || fallback || key;
-    const params = typeof paramsOrFallback === 'object' ? paramsOrFallback : {};
+    const isFallbackString = typeof fallbackOrParams === 'string';
+    const fallback = isFallbackString ? fallbackOrParams : (fallbackWhenParams ?? key);
+    const params = isFallbackString ? {} : (fallbackOrParams || {});
+    const template = translations[key] || fallback;
     return template.replace(/\{\{(\w+)\}\}/g, (_, k) => params[k] ?? '');
   }),
 }));

--- a/custom_components/dashview/frontend/services/status-service.js
+++ b/custom_components/dashview/frontend/services/status-service.js
@@ -1335,26 +1335,26 @@ export function getAlarmStatus(hass, infoTextConfig, alarmEntity) {
   // Map states to display information
   const stateMapping = {
     disarmed: {
-      prefixText: t('status.alarm.disarmed'),
-      badgeText: t('status.alarm.disarmed'),
+      prefixText: t('status.alarm.prefix', 'Alarm is'),
+      badgeText: t('status.alarm.disarmed', 'disarmed'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_home: {
-      prefixText: t('status.alarm.armed_home'),
-      badgeText: t('status.alarm.armed_home'),
+      prefixText: t('status.alarm.prefix', 'Alarm is'),
+      badgeText: t('status.alarm.armed_home', 'armed (Home)'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_away: {
-      prefixText: t('status.alarm.armed_away'),
-      badgeText: t('status.alarm.armed_away'),
+      prefixText: t('status.alarm.prefix', 'Alarm is'),
+      badgeText: t('status.alarm.armed_away', 'armed (Away)'),
       emoji: '🛡️',
       isWarning: false
     },
     armed_night: {
-      prefixText: t('status.alarm.armed_night'),
-      badgeText: t('status.alarm.armed_night'),
+      prefixText: t('status.alarm.prefix', 'Alarm is'),
+      badgeText: t('status.alarm.armed_night', 'armed (Night)'),
       emoji: '🛡️',
       isWarning: false
     },

--- a/custom_components/dashview/frontend/utils/i18n.js
+++ b/custom_components/dashview/frontend/utils/i18n.js
@@ -286,10 +286,10 @@ async function _doInitI18n(lang) {
  *   t('status.lights_on', { count: 3 }) // "3 lights on"
  *   t('greeting', { name: '<script>' }) // "Hello, &lt;script&gt;!" (XSS safe)
  */
-export function t(key, fallbackOrParams = null) {
-  // Determine if second arg is a fallback string or params object
+export function t(key, fallbackOrParams = null, fallbackWhenParams = null) {
+  // Support 3-arg form: t(key, params, fallback) — and 2-arg: t(key, fallback) or t(key, params)
   const isFallbackString = typeof fallbackOrParams === 'string';
-  const fallback = isFallbackString ? fallbackOrParams : key;
+  const fallback = isFallbackString ? fallbackOrParams : (fallbackWhenParams ?? key);
   const params = isFallbackString ? {} : (fallbackOrParams || {});
 
   // Navigate to nested key


### PR DESCRIPTION
## Code Review Fixes

Adversarial code review of recent PRs found 4 issues. All fixed here.

### 🔴 HIGH — Fixed

**1. `t()` ignores 3rd argument (18 call sites affected)**
`t(key, params, fallback)` silently dropped the fallback. Added `fallbackWhenParams` parameter to `t()` in `utils/i18n.js`. Now if a translation key is missing, the English fallback string is returned instead of the raw key.

**2. Alarm status renders duplicate text**
PR #159 set `prefixText` and `badgeText` to the same `t()` call, producing "Entschärft Entschärft". Now `prefixText` uses `status.alarm.prefix` ("Alarm is" / "Alarm ist") and `badgeText` uses the state-specific key.

### 🟡 MEDIUM — Fixed

**3. No tests for `getAlarmStatus()`**
Added 13 tests covering: all 5 alarm states, auto-detection, disabled config, missing entity, unknown state, metadata fields.

**4. Test mock diverged from real `t()` signature**
`anomaly-detector.test.js` mock now matches the real 3-arg `t()` signature.

### Files Changed
| File | Change |
|------|--------|
| `utils/i18n.js` | Support `t(key, params, fallback)` 3-arg form |
| `services/status-service.js` | Fix prefixText to use `status.alarm.prefix` |
| `services/status-service.test.js` | +13 `getAlarmStatus` tests, updated mock |
| `services/anomaly-detector.test.js` | Aligned mock with real `t()` signature |
| `locales/en.json` | Added `status.alarm.prefix` |
| `locales/de.json` | Added `status.alarm.prefix` |

### Testing
`npx vitest run` — **1151 tests pass** (30 test files)