### PR TITLE
chore: bump version to 1.5.0-beta.18

### DIFF
--- a/custom_components/dashview/const.py
+++ b/custom_components/dashview/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "dashview"
 NAME = "Dashview"
-VERSION = "1.5.0-beta.12"
+VERSION = "1.5.0-beta.18"
 
 # Frontend
 URL_BASE = "/dashview_assets"

--- a/custom_components/dashview/manifest.json
+++ b/custom_components/dashview/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/mholzi/dashview/issues",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.5.0-beta.17"
+  "version": "1.5.0-beta.18"
 }


### PR DESCRIPTION
Version bump for pre-release v1.5.0-beta.18