### PR TITLE
fix: sync frontend version to 1.5.0-beta.18

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -52,7 +52,7 @@ if (typeof structuredClone === 'undefined') {
 // Wait for HA frontend to be ready, then load
 (async () => {
   // Version for cache busting - update this when making changes
-  const DASHVIEW_VERSION = "1.5.0-beta.16";
+  const DASHVIEW_VERSION = "1.5.0-beta.18";
 
   // Non-device domains to exclude from entity lists globally
   // These should never appear as room entities even if they carry a matching label


### PR DESCRIPTION
## Summary

Aligns `DASHVIEW_VERSION` in `dashview-panel.js` (`1.5.0-beta.16`) with the backend version in `manifest.json` and `const.py` (`1.5.0-beta.18`).

## Changes

- Updated `DASHVIEW_VERSION` constant in `dashview-panel.js` from `1.5.0-beta.16` → `1.5.0-beta.18`

## Impact

- Fixes cache invalidation issues caused by version mismatch in module query params
- Eliminates development confusion from inconsistent version reporting

Closes #172