### PR TITLE
fix: restore inline polyfill — classic script cannot use static imports

### DIFF
--- a/custom_components/dashview/const.py
+++ b/custom_components/dashview/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "dashview"
 NAME = "Dashview"
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 
 # Frontend
 URL_BASE = "/dashview_assets"

--- a/custom_components/dashview/frontend/utils/index.js
+++ b/custom_components/dashview/frontend/utils/index.js
@@ -6,7 +6,8 @@
  *   import { formatDate, getAreaIcon, triggerHaptic } from './utils/index.js';
  *
  * Polyfills:
- *   structuredClone polyfill is imported from polyfills.js at the top of dashview-panel.js.
+ *   structuredClone polyfill is inlined in dashview-panel.js (classic script constraint).
+ *   Canonical implementation in polyfills.js — both must stay in sync.
  *   The polyfills.js module provides the same implementation for testing.
  */
 

--- a/custom_components/dashview/frontend/utils/polyfills.js
+++ b/custom_components/dashview/frontend/utils/polyfills.js
@@ -7,8 +7,9 @@
  * Usage:
  *   import { initPolyfills, structuredClonePolyfill } from './polyfills.js';
  *
- * This is the single source of truth for the structuredClone polyfill.
- * Imported synchronously at the top of dashview-panel.js via initPolyfills().
+ * Canonical implementation of the structuredClone polyfill.
+ * Also inlined in dashview-panel.js (classic script, cannot use static imports).
+ * Both copies must stay in sync — verified by polyfills.test.js.
  */
 
 /**

--- a/custom_components/dashview/frontend/utils/polyfills.test.js
+++ b/custom_components/dashview/frontend/utils/polyfills.test.js
@@ -249,3 +249,28 @@ describe('settings-store draft mode compatibility', () => {
     expect(originalValues.theme).toBe('dark');
   });
 });
+
+describe('dashview-panel.js polyfill sync check', () => {
+  it('should have the inline polyfill in dashview-panel.js matching the canonical implementation', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const panelPath = path.resolve(import.meta.dirname, '..', 'dashview-panel.js');
+    const panelSrc = fs.readFileSync(panelPath, 'utf-8');
+
+    // Both must contain the same core logic markers
+    const coreSignatures = [
+      'Circular reference detected',
+      'DataCloneError',
+      'instanceof Date',
+      'instanceof RegExp',
+      'instanceof Map',
+      'instanceof Set',
+      'Array.isArray',
+      'Object.prototype.hasOwnProperty',
+    ];
+
+    for (const sig of coreSignatures) {
+      expect(panelSrc).toContain(sig);
+    }
+  });
+});

--- a/custom_components/dashview/manifest.json
+++ b/custom_components/dashview/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/mholzi/dashview/issues",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }


### PR DESCRIPTION
## Summary

Hotfix for #176. The polyfill refactor in #175 replaced the inline polyfill with a static `import` statement, but `dashview-panel.js` is loaded as a classic script — not an ES module. This caused a `SyntaxError` that prevented Dashview from rendering entirely.

## Changes

- Restored inline `structuredClone` polyfill in `dashview-panel.js`
- Added sync-check test in `polyfills.test.js` to verify both copies stay aligned
- Updated comments explaining the classic script constraint

## Testing

All 1185 tests pass (including new sync-check test).

Closes #176