### PR TITLE
fix: always re-register panel to update js_url after version bumps

### DIFF
--- a/custom_components/dashview/const.py
+++ b/custom_components/dashview/const.py
@@ -2,7 +2,7 @@
 
 DOMAIN = "dashview"
 NAME = "Dashview"
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 
 # Frontend
 URL_BASE = "/dashview_assets"

--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -55,7 +55,7 @@ if (typeof structuredClone === 'undefined') {
 // Wait for HA frontend to be ready, then load
 (async () => {
   // Version for cache busting - update this when making changes
-  const DASHVIEW_VERSION = "1.5.1";
+  const DASHVIEW_VERSION = "1.5.2";
 
   // Non-device domains to exclude from entity lists globally
   // These should never appear as room entities even if they carry a matching label

--- a/custom_components/dashview/manifest.json
+++ b/custom_components/dashview/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/mholzi/dashview/issues",
   "iot_class": "local_push",
   "requirements": [],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }


### PR DESCRIPTION
## Summary

Fixes the black screen issue after upgrading Dashview. The panel registration was skipped if the panel already existed in `frontend_panels`, causing the old `js_url` (with stale version query param) to persist after a version bump + HA restart.

This meant the browser loaded a cached/broken script from the previous version instead of the new one.

## Fix

Remove + re-register the panel on every `async_setup_frontend` call to ensure the `js_url` always reflects the current `VERSION`.

## Root Cause

The v1.5.0 → v1.5.1 upgrade introduced this sequence:
1. v1.5.0 registered panel with `?v=1.5.0` (broken static import)
2. v1.5.1 fixed the code but the panel check saw 'already registered' → skipped
3. HA kept serving the old `?v=1.5.0` URL → browser loaded cached broken script → black screen

Closes #176