### PR TITLE
feat: wire up smart suggestions + complete schema validation

### DIFF
--- a/custom_components/dashview/frontend/dashview-panel.js
+++ b/custom_components/dashview/frontend/dashview-panel.js
@@ -180,6 +180,7 @@ if (typeof structuredClone === 'undefined') {
   let statusService = null;
   let weatherService = null;
   let anomalyDetector = null;
+  let suggestionEngine = null;
   try {
     const servicesModule = await import(`./services/index.js?v=${DASHVIEW_VERSION}`);
     roomDataService = servicesModule.getRoomDataService();
@@ -211,6 +212,11 @@ if (typeof structuredClone === 'undefined') {
     anomalyDetector = {
       detectTemperatureAnomaly: servicesModule.detectTemperatureAnomaly,
       detectHumidityAnomaly: servicesModule.detectHumidityAnomaly,
+    };
+    suggestionEngine = {
+      evaluateSuggestions: servicesModule.evaluateSuggestions,
+      dismissSuggestion: servicesModule.dismissSuggestion,
+      recordSuggestionAction: servicesModule.recordSuggestionAction,
     };
     debugLog("Loaded services module");
   } catch (e) {
@@ -345,6 +351,8 @@ if (typeof structuredClone === 'undefined') {
         _editingRoomSceneButton: { type: String },
         // Changelog
         _changelogPageIndex: { type: Number },
+        // Smart suggestions
+        _activeSuggestions: { type: Array },
         // Floor overview
         _floorOverviewIndex: { type: Object },
       };
@@ -466,6 +474,8 @@ if (typeof structuredClone === 'undefined') {
       this._entitySearchDebounceTimers = {};
       // Thermostat swipe index per room
       this._thermostatSwipeIndex = {};
+      // Smart suggestions
+      this._activeSuggestions = [];
       // Changelog popup state
       this._changelogPopupOpen = false;
       this._changelogPageIndex = 0;
@@ -797,6 +807,72 @@ if (typeof structuredClone === 'undefined') {
     _handleRoofWindowOpenTooLongChange(e) { this._handleThresholdChange('_roofWindowOpenTooLongMinutes', 5, 1440, e); }
     _handleCoverOpenTooLongChange(e) { this._handleThresholdChange('_coverOpenTooLongMinutes', 5, 1440, e); }
     _handleLockUnlockedTooLongChange(e) { this._handleThresholdChange('_lockUnlockedTooLongMinutes', 5, 1440, e); }
+
+    // ============================================
+    // Smart Suggestions
+    // ============================================
+
+    /**
+     * Evaluate and update active suggestions based on current state
+     */
+    _updateSuggestions() {
+      if (!suggestionEngine || !this.hass) {
+        this._activeSuggestions = [];
+        return;
+      }
+      const context = {
+        enabledMaps: {
+          enabledLights: this._enabledLights,
+          enabledClimates: this._enabledClimates,
+          enabledWindows: this._enabledWindows,
+        },
+        labelIds: {
+          light: this._lightLabelId,
+          climate: this._climateLabelId,
+          window: this._windowLabelId,
+        },
+        entityHasLabel: (entityId, labelId) => this._entityHasCurrentLabel(entityId, labelId),
+        getAreaIdForEntity: (entityId) => this._getAreaIdForEntity(entityId),
+      };
+      this._activeSuggestions = suggestionEngine.evaluateSuggestions(this.hass, context);
+    }
+
+    /**
+     * Handle user clicking a suggestion action button
+     * @param {Object} suggestion - Suggestion object from the engine
+     */
+    _handleSuggestionAction(suggestion) {
+      if (!suggestion?.actionData) return;
+      const { actionType, actionData } = suggestion;
+
+      if (actionType === 'service' && actionData.domain && actionData.service) {
+        // Call HA service for each entity
+        (actionData.entityIds || []).forEach(entityId => {
+          this.hass.callService(actionData.domain, actionData.service, {
+            entity_id: entityId,
+          });
+        });
+      } else if (actionType === 'popup' && actionData.popup === 'lights') {
+        this._lightsPopupOpen = true;
+      }
+
+      // Record the action and refresh suggestions
+      if (suggestionEngine) {
+        suggestionEngine.recordSuggestionAction(suggestion.id);
+      }
+      this._updateSuggestions();
+    }
+
+    /**
+     * Handle user dismissing a suggestion
+     * @param {Object} suggestion - Suggestion object from the engine
+     */
+    _handleSuggestionDismiss(suggestion) {
+      if (!suggestion?.id || !suggestionEngine) return;
+      // Default cooldown of 60 minutes
+      suggestionEngine.dismissSuggestion(suggestion.id, 60 * 60 * 1000);
+      this._updateSuggestions();
+    }
 
     /**
      * Set a category's label mapping
@@ -1610,6 +1686,8 @@ if (typeof structuredClone === 'undefined') {
         if (this._weatherForecasts.length === 0) {
           this._fetchWeatherForecasts();
         }
+        // Evaluate smart suggestions based on current state
+        this._updateSuggestions();
       }
     }
 

--- a/custom_components/dashview/frontend/utils/schema-validator.js
+++ b/custom_components/dashview/frontend/utils/schema-validator.js
@@ -91,6 +91,24 @@ export const SETTINGS_SCHEMA = {
     max: 1440,
     default: THRESHOLDS?.DEFAULT_GARAGE_OPEN_TOO_LONG_MINUTES ?? 30
   },
+  roofWindowOpenTooLongMinutes: {
+    type: 'number',
+    min: 5,
+    max: 1440,
+    default: THRESHOLDS?.DEFAULT_ROOF_WINDOW_OPEN_TOO_LONG_MINUTES ?? 120
+  },
+  coverOpenTooLongMinutes: {
+    type: 'number',
+    min: 5,
+    max: 1440,
+    default: THRESHOLDS?.DEFAULT_COVER_OPEN_TOO_LONG_MINUTES ?? 240
+  },
+  lockUnlockedTooLongMinutes: {
+    type: 'number',
+    min: 5,
+    max: 1440,
+    default: THRESHOLDS?.DEFAULT_LOCK_UNLOCKED_TOO_LONG_MINUTES ?? 30
+  },
 
   // Weather entity configuration
   weatherEntity: { type: 'string', default: 'weather.forecast_home' },
@@ -139,6 +157,31 @@ export const SETTINGS_SCHEMA = {
 
   // User photos
   userPhotos: { type: 'object', default: {} },
+
+  // Alarm entity
+  alarmEntity: { type: 'string', default: '' },
+
+  // Cover position inversion map
+  coverInvertPosition: { type: 'object', default: {} },
+
+  // Language override (null = follow HA, 'en'/'de' = override)
+  manualLanguage: { type: 'stringOrNull', default: null },
+
+  // Weather radar settings
+  weatherRadarLat: { type: 'number', min: -90, max: 90, default: 50.0 },
+  weatherRadarLon: { type: 'number', min: -180, max: 180, default: 8.7 },
+  weatherRadarZoom: { type: 'number', min: 1, max: 20, default: 9 },
+  weatherRadarTempUnit: { type: 'string', default: '°C' },
+  weatherRadarWindUnit: { type: 'string', default: 'km/h' },
+
+  // Pollen configuration
+  pollenConfig: { type: 'object', default: { enabled: true, enabledSensors: {}, displayMode: 'active' } },
+
+  // Train departures
+  trainDepartures: { type: 'array', default: [] },
+
+  // Enabled doors map
+  enabledDoors: { type: 'object', default: {} },
 };
 
 /**


### PR DESCRIPTION
## Summary
- **#207** — Wire the fully-built suggestion engine into the dashboard. ~60 lines of glue code: evaluate suggestions on every hass update, handle action buttons (HA service calls), handle dismiss (60min cooldown). The home tab already renders them via `renderSuggestionsBanner()`.
- **#210** — Add 13 missing fields to `SETTINGS_SCHEMA`: 3 open-too-long thresholds, alarm entity, cover inversion, manual language, 5 weather radar settings, pollen config, train departures, enabled doors.

## Test plan
- [x] All 1185 tests pass
- [ ] Smart suggestions appear on home tab when conditions are met (e.g., lights on after 23:00)
- [ ] Dismiss button hides suggestion for 60 minutes
- [ ] Action button executes the correct HA service call
- [ ] Corrupted settings for newly validated fields are caught and replaced with defaults

Closes #207, closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)